### PR TITLE
remove __geo_interface__ functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ class State(GeoAgent):
 
 class GeoModel(Model):
     def __init__(self):
-        self.grid = GeoSpace()
+        self.space = GeoSpace()
         
         state_agent_kwargs = dict(model=self)
         AC = AgentCreator(agent_class=State, agent_kwargs=state_agent_kwargs)
         agents = AC.from_GeoJSON(GeoJSON=geojson_states, unique_id="NAME")
-        self.grid.add_agents(agents)
+        self.space.add_agents(agents)
 ```
 
 In the `GeoModel` we first create an instance of AgentCreator, where we provide the Agent class (State) and its required arguments, except shape and unique_id. We then use the `.from_GeoJSON` function to create our agents from the shapes in the GeoJSON file. We provide the feature "name" as the key from which the agents get their unique_ids.
@@ -65,7 +65,7 @@ Let's instantiate our model and look at one of the agents:
 ```python
 m = GeoModel()
 
-agent = m.grid.agents[0]
+agent = m.space.agents[0]
 print(agent.unique_id)
 agent.shape
 ```
@@ -87,7 +87,7 @@ agent.CENSUSAREA
 Let's start to do some spatial analysis. We can use usual Mesa function names to get neighboring states
 
 ```python
-neighbors = m.grid.get_neighbors(agent)
+neighbors = m.space.get_neighbors(agent)
 print([a.unique_id for a in neighbors])
 ```
 
@@ -100,7 +100,7 @@ print([a.unique_id for a in neighbors])
 To get a list of all states within a certain distance you can use the following
 
 ```python
-[a.unique_id for a in m.grid.get_neighbors_within_distance(agent, 600000)]
+[a.unique_id for a in m.space.get_neighbors_within_distance(agent, 600000)]
 ```
 
     ['California',

--- a/examples/GeoSIR/model.py
+++ b/examples/GeoSIR/model.py
@@ -53,7 +53,7 @@ class PersonAgent(GeoAgent):
         """Advance one step."""
         # If susceptible, check if exposed
         if self.atype == "susceptible":
-            neighbors = self.model.grid.get_neighbors_within_distance(
+            neighbors = self.model.space.get_neighbors_within_distance(
                 self, self.model.exposure_distance
             )
             for neighbor in neighbors:
@@ -109,7 +109,7 @@ class NeighbourhoodAgent(GeoAgent):
 
     def color_hotspot(self):
         # Decide if this region agent is a hot-spot (if more than threshold person agents are infected)
-        neighbors = self.model.grid.get_intersecting_agents(self)
+        neighbors = self.model.space.get_intersecting_agents(self)
         infected_neighbors = [
             neighbor for neighbor in neighbors if neighbor.atype == "infected"
         ]
@@ -139,7 +139,7 @@ class InfectedModel(Model):
         :param infection_risk:      Probability of agent to become infected, if it has been exposed to another infected
         """
         self.schedule = BaseScheduler(self)
-        self.grid = GeoSpace()
+        self.space = GeoSpace()
         self.steps = 0
         self.counts = None
         self.reset_counts()
@@ -165,7 +165,7 @@ class InfectedModel(Model):
         neighbourhood_agents = AC.from_file(
             self.geojson_regions, unique_id=self.unique_id
         )
-        self.grid.add_agents(neighbourhood_agents)
+        self.space.add_agents(neighbourhood_agents)
 
         # Generate PersonAgent population
         ac_population = AgentCreator(
@@ -189,7 +189,7 @@ class InfectedModel(Model):
             this_person = ac_population.create_agent(
                 Point(this_x, this_y), "P" + str(i)
             )
-            self.grid.add_agents(this_person)
+            self.space.add_agents(this_person)
             self.schedule.add(this_person)
 
         # Add the neighbourhood agents to schedule AFTER person agents,
@@ -214,7 +214,7 @@ class InfectedModel(Model):
         self.steps += 1
         self.reset_counts()
         self.schedule.step()
-        self.grid._recreate_rtree()  # Recalculate spatial tree, because agents are moving
+        self.space._recreate_rtree()  # Recalculate spatial tree, because agents are moving
 
         self.datacollector.collect(self)
 

--- a/examples/GeoSchelling/model.py
+++ b/examples/GeoSchelling/model.py
@@ -23,7 +23,7 @@ class SchellingAgent(GeoAgent):
         """Advance agent one step."""
         similar = 0
         different = 0
-        neighbors = self.model.grid.get_neighbors(self)
+        neighbors = self.model.space.get_neighbors(self)
         if neighbors:
             for neighbor in neighbors:
                 if neighbor.atype is None:
@@ -36,7 +36,7 @@ class SchellingAgent(GeoAgent):
         # If unhappy, move:
         if similar < different:
             # Select an empty region
-            empties = [a for a in self.model.grid.agents if a.atype is None]
+            empties = [a for a in self.model.space.agents if a.atype is None]
             # Switch atypes and add/remove from scheduler
             new_region = random.choice(empties)
             new_region.atype = self.atype
@@ -58,7 +58,7 @@ class SchellingModel(Model):
         self.minority_pc = minority_pc
 
         self.schedule = RandomActivation(self)
-        self.grid = GeoSpace()
+        self.space = GeoSpace()
 
         self.happy = 0
         self.datacollector = DataCollector({"happy": "happy"})
@@ -68,7 +68,7 @@ class SchellingModel(Model):
         # Set up the grid with patches for every NUTS region
         AC = AgentCreator(SchellingAgent, {"model": self})
         agents = AC.from_file("nuts_rg_60M_2013_lvl_2.geojson")
-        self.grid.add_agents(agents)
+        self.space.add_agents(agents)
 
         # Set up agents
         for agent in agents:

--- a/mesa_geo/geoagent.py
+++ b/mesa_geo/geoagent.py
@@ -5,12 +5,14 @@ Core Objects: GeoAgent
 
 """
 import json
+import warnings
+
 import geopandas as gpd
+import pyproj
 from mesa import Agent
 from shapely.ops import transform
 from shapely.geometry import mapping
 from shapely.geometry.base import BaseGeometry
-import warnings
 
 
 class GeoAgent(Agent):
@@ -28,20 +30,24 @@ class GeoAgent(Agent):
         self.shape = shape
         self._geom = self.shape._geom
 
+    def get_transformed_geometry(self, transformer):
+        """
+        Return the transformed geometry given a transformer.
+        """
+        return transform(transformer.transform, self.shape)
+
     def step(self):
         """Advance one step."""
         pass
 
     def __geo_interface__(self):
         """Return a GeoJSON Feature.
-
         Removes shape from attributes.
         """
         properties = dict(vars(self))
         properties["model"] = str(self.model)
         shape = properties.pop("shape")
-
-        shape = transform(self.model.grid.Transformer.transform, shape)
+        shape = transform(self.model.space.Transformer.transform, shape)
 
         return {"type": "Feature", "geometry": mapping(shape), "properties": properties}
 

--- a/mesa_geo/geospace.py
+++ b/mesa_geo/geospace.py
@@ -37,7 +37,9 @@ class GeoSpace:
         """
         self.crs = pyproj.CRS(crs)
         self.WGS84 = pyproj.CRS("epsg:4326")
-        self.Transformer = pyproj.Transformer.from_crs(self.crs, self.WGS84, always_xy=True)
+        self.Transformer = pyproj.Transformer.from_crs(
+            self.crs, self.WGS84, always_xy=True
+        )
 
         self.bbox = None
         self._neighborhood = None
@@ -93,7 +95,9 @@ class GeoSpace:
         intersecting_agents = self.get_relation(agent, "intersects")
         return intersecting_agents
 
-    def get_neighbors_within_distance(self, agent, distance, center=False, relation="intersects"):
+    def get_neighbors_within_distance(
+        self, agent, distance, center=False, relation="intersects"
+    ):
         """Return a list of agents within `distance` of `agent`.
 
         Distance is measured as a buffer around the agent's shape,

--- a/tests/test_MapModule.py
+++ b/tests/test_MapModule.py
@@ -1,0 +1,49 @@
+import unittest
+import uuid
+
+from mesa.model import Model
+from shapely.geometry import Point
+
+from mesa_geo import AgentCreator, GeoAgent, GeoSpace
+from mesa_geo.visualization.MapModule import MapModule
+
+
+class TestMapModule(unittest.TestCase):
+    def setUp(self) -> None:
+        self.model = Model()
+        self.model.space = GeoSpace()
+        self.agent_creator = AgentCreator(
+            agent_class=GeoAgent, agent_kwargs={"model": self.model}
+        )
+        self.shapes = [Point(1, 1)] * 7
+        self.agents = [
+            self.agent_creator.create_agent(shape=shape, unique_id=uuid.uuid4().int)
+            for shape in self.shapes
+        ]
+        self.model.space.add_agents(self.agents)
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_render(self):
+        map_module = MapModule(portrayal_method=lambda x: {"color": "red", "radius": 7})
+        self.assertDictEqual(
+            map_module.render(self.model),
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": (
+                                8.983152841195214e-06,
+                                8.983152841195177e-06,
+                            ),
+                        },
+                        "properties": {"color": "red", "radius": 7},
+                    }
+                ]
+                * len(self.agents),
+            },
+        )


### PR DESCRIPTION
1. Fix https://github.com/projectmesa/mesa-geo/issues/32
2. Change `model.grid` to `model.space` for better naming convention, since `GeoSpace` is not necessarily a `grid`.