### PR TITLE
remove deprecated skip_equivalent from pyproj

### DIFF
--- a/mesa_geo/geospace.py
+++ b/mesa_geo/geospace.py
@@ -93,9 +93,7 @@ class GeoSpace:
         intersecting_agents = self.get_relation(agent, "intersects")
         return intersecting_agents
 
-    def get_neighbors_within_distance(
-            self, agent, distance, center=False, relation="intersects"
-    ):
+    def get_neighbors_within_distance(self, agent, distance, center=False, relation="intersects"):
         """Return a list of agents within `distance` of `agent`.
 
         Distance is measured as a buffer around the agent's shape,

--- a/mesa_geo/geospace.py
+++ b/mesa_geo/geospace.py
@@ -37,9 +37,7 @@ class GeoSpace:
         """
         self.crs = pyproj.CRS(crs)
         self.WGS84 = pyproj.CRS("epsg:4326")
-        self.Transformer = pyproj.Transformer.from_crs(
-            self.crs, self.WGS84, skip_equivalent=True, always_xy=True
-        )
+        self.Transformer = pyproj.Transformer.from_crs(self.crs, self.WGS84, always_xy=True)
 
         self.bbox = None
         self._neighborhood = None
@@ -96,7 +94,7 @@ class GeoSpace:
         return intersecting_agents
 
     def get_neighbors_within_distance(
-        self, agent, distance, center=False, relation="intersects"
+            self, agent, distance, center=False, relation="intersects"
     ):
         """Return a list of agents within `distance` of `agent`.
 


### PR DESCRIPTION
Fix https://github.com/projectmesa/mesa-geo/issues/39 due to https://github.com/pyproj4/pyproj/pull/824