### PR TITLE
rename InstallCommand to BuildCommand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import pkgutil
 import re
 import shutil
 import sys
+from distutils.command.build import build
 
 from setuptools import setup
 from setuptools.command.develop import develop
-from setuptools.command.install import install
 
 
 def get_version_from_package() -> str:
@@ -27,12 +27,12 @@ class DevelopCommand(develop):
         develop.run(self)
 
 
-class InstallCommand(install):
-    """Installation for installation mode."""
+class BuildCommand(build):
+    """Command for build mode."""
 
     def run(self):
         get_mesa_viz_files()
-        install.run(self)
+        build.run(self)
 
 
 def get_mesa_viz_files():
@@ -66,6 +66,6 @@ if __name__ == "__main__":
         version=get_version_from_package(),
         cmdclass={
             "develop": DevelopCommand,
-            "install": InstallCommand,
+            "build": BuildCommand,
         },
     )


### PR DESCRIPTION
Previously the `package_data` files were missing from binary and source distributions, because `distutils.command.bdist.bdist` and `distutils.command.sdist.sdist` were not customized in similar ways.

For example if `git+https://github.com/projectmesa/mesa-geo.git#egg=mesa-geo` is included in a `requirements.txt` file from a downstream project such as https://github.com/wang-boyu/agents-and-networks-in-python, the `package_data` won't be available.

With this PR:

- `DevelopCommand` makes `python3 -m pip install -e .` working (run from this repo).
- `BuildCommand` makes `python3 -m pip install .` working (run from this repo).
- `BuildCommand` also makes `python3 -m pip install -r requirements.txt` working (run from downstream projects).
