### PR TITLE
rename GeoAgent's shape attribute to geometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mesa-Geo: a GIS extension for the Mesa agent-based modeling framework in Python
 
-Mesa-Geo implements a `GeoSpace` that can host GIS-based `GeoAgents`, which are like normal Agents, except they have a `shape` attribute that is a [Shapely object](https://shapely.readthedocs.io/en/latest/manual.html). You can use `Shapely` directly to create arbitrary shapes, but in most cases you will want to import your shapes from a file. Mesa-Geo allows you to create GeoAgents from any vector data file (e.g. shapefiles), valid GeoJSON objects or a GeoPandas GeoDataFrame.
+Mesa-Geo implements a `GeoSpace` that can host GIS-based `GeoAgents`, which are like normal Agents, except they have a `geometry` attribute that is a [Shapely object](https://shapely.readthedocs.io/en/latest/manual.html). You can use `Shapely` directly to create arbitrary geometries, but in most cases you will want to import your geometries from a file. Mesa-Geo allows you to create GeoAgents from any vector data file (e.g. shapefiles), valid GeoJSON objects or a GeoPandas GeoDataFrame.
 
 ## Installation
 
@@ -27,7 +27,7 @@ pip install -e git+https://github.com/projectmesa/mesa-geo.git#egg=mesa-geo
 
 You should be familiar with how [Mesa](https://github.com/projectmesa/mesa) works.
 
-So let's get started with some shapes! We will work with [records of US states](http://eric.clst.org/Stuff/USGeoJSON). We use the `requests` library to retrieve the data, but of course you can work with local data.
+So let's get started with some geometries! We will work with [records of US states](http://eric.clst.org/Stuff/USGeoJSON). We use the `requests` library to retrieve the data, but of course you can work with local data.
 
 ```python
 from mesa_geo import GeoSpace, GeoAgent, AgentCreator
@@ -42,8 +42,8 @@ First we create a `State` Agent and a `GeoModel`. Both should look familiar if y
 
 ```python
 class State(GeoAgent):
-    def __init__(self, unique_id, model, shape):
-        super().__init__(unique_id, model, shape)
+    def __init__(self, unique_id, model, geometry):
+        super().__init__(unique_id, model, geometry)
 
 class GeoModel(Model):
     def __init__(self):
@@ -55,7 +55,7 @@ class GeoModel(Model):
         self.space.add_agents(agents)
 ```
 
-In the `GeoModel` we first create an instance of AgentCreator, where we provide the Agent class (State) and its required arguments, except shape and unique_id. We then use the `.from_GeoJSON` function to create our agents from the shapes in the GeoJSON file. We provide the feature "name" as the key from which the agents get their unique_ids.
+In the `GeoModel` we first create an instance of AgentCreator, where we provide the Agent class (State) and its required arguments, except geometry and unique_id. We then use the `.from_GeoJSON` function to create our agents from the geometries in the GeoJSON file. We provide the feature "name" as the key from which the agents get their unique_ids.
 Finally, we add the agents to the GeoSpace
 
 Let's instantiate our model and look at one of the agents:
@@ -65,10 +65,10 @@ m = GeoModel()
 
 agent = m.space.agents[0]
 print(agent.unique_id)
-agent.shape
+agent.geometry
 ```
 
-If you work in the Jupyter Notebook your output should give you the name of the state and a visual representation of the shape.
+If you work in the Jupyter Notebook your output should give you the name of the state and a visual representation of the geometry.
 
     Arizona
 

--- a/examples/GeoSIR/model.py
+++ b/examples/GeoSIR/model.py
@@ -13,7 +13,7 @@ class PersonAgent(GeoAgent):
         self,
         unique_id,
         model,
-        shape,
+        geometry,
         agent_type="susceptible",
         mobility_range=100,
         recovery_rate=0.2,
@@ -24,11 +24,11 @@ class PersonAgent(GeoAgent):
         Create a new person agent.
         :param unique_id:   Unique identifier for the agent
         :param model:       Model in which the agent runs
-        :param shape:       Shape object for the agent
+        :param geometry:    Shape object for the agent
         :param agent_type:  Indicator if agent is infected ("infected", "susceptible", "recovered" or "dead")
         :param mobility_range:  Range of distance to move in one step
         """
-        super().__init__(unique_id, model, shape)
+        super().__init__(unique_id, model, geometry)
         # Agent parameters
         self.atype = agent_type
         self.mobility_range = mobility_range
@@ -47,7 +47,7 @@ class PersonAgent(GeoAgent):
         :param dx:  Distance to move in x-axis
         :param dy:  Distance to move in y-axis
         """
-        return Point(self.shape.x + dx, self.shape.y + dy)
+        return Point(self.geometry.x + dx, self.geometry.y + dy)
 
     def step(self):
         """Advance one step."""
@@ -75,7 +75,7 @@ class PersonAgent(GeoAgent):
         if self.atype != "dead":
             move_x = self.random.randint(-self.mobility_range, self.mobility_range)
             move_y = self.random.randint(-self.mobility_range, self.mobility_range)
-            self.shape = self.move_point(move_x, move_y)  # Reassign shape
+            self.geometry = self.move_point(move_x, move_y)  # Reassign geometry
 
         self.model.counts[self.atype] += 1  # Count agent type
 
@@ -86,16 +86,18 @@ class PersonAgent(GeoAgent):
 class NeighbourhoodAgent(GeoAgent):
     """Neighbourhood agent. Changes color according to number of infected inside it."""
 
-    def __init__(self, unique_id, model, shape, agent_type="safe", hotspot_threshold=1):
+    def __init__(
+        self, unique_id, model, geometry, agent_type="safe", hotspot_threshold=1
+    ):
         """
         Create a new Neighbourhood agent.
         :param unique_id:   Unique identifier for the agent
         :param model:       Model in which the agent runs
-        :param shape:       Shape object for the agent
+        :param geometry:    Shape object for the agent
         :param agent_type:  Indicator if agent is infected ("infected", "susceptible", "recovered" or "dead")
         :param hotspot_threshold:   Number of infected agents in region to be considered a hot-spot
         """
-        super().__init__(unique_id, model, shape)
+        super().__init__(unique_id, model, geometry)
         self.atype = agent_type
         self.hotspot_threshold = (
             hotspot_threshold  # When a neighborhood is considered a hot-spot
@@ -178,8 +180,8 @@ class InfectedModel(Model):
             )  # Region where agent starts
             center_x, center_y = neighbourhood_agents[
                 this_neighbourhood
-            ].shape.centroid.coords.xy
-            this_bounds = neighbourhood_agents[this_neighbourhood].shape.bounds
+            ].geometry.centroid.coords.xy
+            this_bounds = neighbourhood_agents[this_neighbourhood].geometry.bounds
             spread_x = int(
                 this_bounds[2] - this_bounds[0]
             )  # Heuristic for agent spread in region

--- a/examples/GeoSchelling/model.py
+++ b/examples/GeoSchelling/model.py
@@ -9,14 +9,14 @@ import random
 class SchellingAgent(GeoAgent):
     """Schelling segregation agent."""
 
-    def __init__(self, unique_id, model, shape, agent_type=None):
+    def __init__(self, unique_id, model, geometry, agent_type=None):
         """Create a new Schelling agent.
 
         Args:
             unique_id: Unique identifier for the agent.
             agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model, shape)
+        super().__init__(unique_id, model, geometry)
         self.atype = agent_type
 
     def step(self):

--- a/tests/test_AgentCreator.py
+++ b/tests/test_AgentCreator.py
@@ -1,17 +1,62 @@
 import unittest
-from mesa_geo.geoagent import GeoAgent, AgentCreator
+
+import pandas as pd
+import geopandas as gpd
 from shapely.geometry import Point
+
+from mesa_geo.geoagent import GeoAgent, AgentCreator
 
 
 class TestAgentCreator(unittest.TestCase):
+    def setUp(self) -> None:
+        self.agent_creator = AgentCreator(
+            agent_class=GeoAgent, agent_kwargs={"model": None}
+        )
+        self.df = pd.DataFrame(
+            {
+                "City": ["Buenos Aires", "Brasilia", "Santiago", "Bogota", "Caracas"],
+                "Country": ["Argentina", "Brazil", "Chile", "Colombia", "Venezuela"],
+                "Latitude": [-34.58, -15.78, -33.45, 4.60, 10.48],
+                "Longitude": [-58.66, -47.91, -70.66, -74.08, -66.86],
+            }
+        )
+
+    def tearDown(self) -> None:
+        pass
+
     def test_create_agent(self):
-        AC = AgentCreator(agent_class=GeoAgent, agent_kwargs={"model": None})
-        shape = Point(1, 1)
-        agent = AC.create_agent(shape=shape, unique_id=0)
-        assert isinstance(agent, GeoAgent)
-        assert agent.shape == shape
-        assert agent.model is None
+        agent = self.agent_creator.create_agent(geometry=Point(1, 1), unique_id=0)
+        self.assertIsInstance(agent, GeoAgent)
+        self.assertEqual(agent.geometry, Point(1, 1))
+        self.assertIsNone(agent.model)
 
+    def test_from_GeoDataFrame_with_default_geometry_name(self):
+        gdf = gpd.GeoDataFrame(
+            self.df,
+            geometry=gpd.points_from_xy(self.df.Longitude, self.df.Latitude),
+            crs="epsg:3857",
+        )
+        agents = self.agent_creator.from_GeoDataFrame(gdf)
 
-if __name__ == "__main__":
-    unittest.main()
+        self.assertEqual(len(agents), 5)
+
+        self.assertEqual(agents[0].City, "Buenos Aires")
+        self.assertEqual(agents[0].Country, "Argentina")
+        self.assertEqual(agents[0].geometry, Point(-58.66, -34.58))
+
+    def test_from_GeoDataFrame_with_custom_geometry_name(self):
+        gdf = gpd.GeoDataFrame(
+            self.df,
+            geometry=gpd.points_from_xy(self.df.Longitude, self.df.Latitude),
+            crs="epsg:3857",
+        )
+        gdf.rename_geometry("custom_name", inplace=True)
+
+        agents = self.agent_creator.from_GeoDataFrame(gdf)
+
+        self.assertEqual(len(agents), 5)
+
+        self.assertEqual(agents[0].City, "Buenos Aires")
+        self.assertEqual(agents[0].Country, "Argentina")
+        self.assertEqual(agents[0].geometry, Point(-58.66, -34.58))
+        self.assertFalse(hasattr(agents[0], "custom_name"))

--- a/tests/test_GeoSpace.py
+++ b/tests/test_GeoSpace.py
@@ -12,10 +12,12 @@ class TestGeoSpace(unittest.TestCase):
         self.agent_creator = AgentCreator(
             agent_class=GeoAgent, agent_kwargs={"model": None}
         )
-        self.shapes = [Point(1, 1)] * 7
+        self.geometries = [Point(1, 1)] * 7
         self.agents = [
-            self.agent_creator.create_agent(shape=shape, unique_id=uuid.uuid4().int)
-            for shape in self.shapes
+            self.agent_creator.create_agent(
+                geometry=geometry, unique_id=uuid.uuid4().int
+            )
+            for geometry in self.geometries
         ]
         self.geo_space = GeoSpace()
 

--- a/tests/test_MapModule.py
+++ b/tests/test_MapModule.py
@@ -15,10 +15,12 @@ class TestMapModule(unittest.TestCase):
         self.agent_creator = AgentCreator(
             agent_class=GeoAgent, agent_kwargs={"model": self.model}
         )
-        self.shapes = [Point(1, 1)] * 7
+        self.geometries = [Point(1, 1)] * 7
         self.agents = [
-            self.agent_creator.create_agent(shape=shape, unique_id=uuid.uuid4().int)
-            for shape in self.shapes
+            self.agent_creator.create_agent(
+                geometry=geometry, unique_id=uuid.uuid4().int
+            )
+            for geometry in self.geometries
         ]
         self.model.space.add_agents(self.agents)
 


### PR DESCRIPTION
This PR is motivated by the discussions from https://github.com/projectmesa/mesa-geo/issues/37.

Essentially it is to be consistent with the convention used in Shapefile and GeoPandas, that the spatial feature column is named `geometry` rather than `shape`.