### PR TITLE
Feat/crs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mesa-Geo: a GIS extension for the Mesa agent-based modeling framework in Python
 
-Mesa-Geo implements a `GeoSpace` that can host GIS-based `GeoAgents`, which are like normal Agents, except they have a `geometry` attribute that is a [Shapely object](https://shapely.readthedocs.io/en/latest/manual.html). You can use `Shapely` directly to create arbitrary geometries, but in most cases you will want to import your geometries from a file. Mesa-Geo allows you to create GeoAgents from any vector data file (e.g. shapefiles), valid GeoJSON objects or a GeoPandas GeoDataFrame.
+Mesa-Geo implements a `GeoSpace` that can host GIS-based `GeoAgents`, which are like normal Agents, except they have a `geometry` attribute that is a [Shapely object](https://shapely.readthedocs.io/en/latest/manual.html) and a `crs` attribute for its Coordinate Reference System. You can use `Shapely` directly to create arbitrary geometries, but in most cases you will want to import your geometries from a file. Mesa-Geo allows you to create GeoAgents from any vector data file (e.g. shapefiles), valid GeoJSON objects or a GeoPandas GeoDataFrame.
 
 ## Installation
 
@@ -42,16 +42,15 @@ First we create a `State` Agent and a `GeoModel`. Both should look familiar if y
 
 ```python
 class State(GeoAgent):
-    def __init__(self, unique_id, model, geometry):
-        super().__init__(unique_id, model, geometry)
+    def __init__(self, unique_id, model, geometry, crs):
+        super().__init__(unique_id, model, geometry, crs)
 
 class GeoModel(Model):
     def __init__(self):
         self.space = GeoSpace()
         
-        state_agent_kwargs = dict(model=self)
-        AC = AgentCreator(agent_class=State, agent_kwargs=state_agent_kwargs)
-        agents = AC.from_GeoJSON(GeoJSON=geojson_states, unique_id="NAME")
+        ac = AgentCreator(agent_class=State, model=self)
+        agents = ac.from_GeoJSON(GeoJSON=geojson_states, unique_id="NAME")
         self.space.add_agents(agents)
 ```
 

--- a/examples/GeoSchelling/model.py
+++ b/examples/GeoSchelling/model.py
@@ -9,14 +9,14 @@ import random
 class SchellingAgent(GeoAgent):
     """Schelling segregation agent."""
 
-    def __init__(self, unique_id, model, geometry, agent_type=None):
+    def __init__(self, unique_id, model, geometry, crs, agent_type=None):
         """Create a new Schelling agent.
 
         Args:
             unique_id: Unique identifier for the agent.
             agent_type: Indicator for the agent's type (minority=1, majority=0)
         """
-        super().__init__(unique_id, model, geometry)
+        super().__init__(unique_id, model, geometry, crs)
         self.atype = agent_type
 
     def step(self):
@@ -66,8 +66,8 @@ class SchellingModel(Model):
         self.running = True
 
         # Set up the grid with patches for every NUTS region
-        AC = AgentCreator(SchellingAgent, {"model": self})
-        agents = AC.from_file("nuts_rg_60M_2013_lvl_2.geojson")
+        ac = AgentCreator(SchellingAgent, model=self)
+        agents = ac.from_file("nuts_rg_60M_2013_lvl_2.geojson")
         self.space.add_agents(agents)
 
         # Set up agents

--- a/mesa_geo/geoagent.py
+++ b/mesa_geo/geoagent.py
@@ -8,26 +8,42 @@ import json
 import warnings
 
 import geopandas as gpd
+import pyproj
 from mesa import Agent
-from shapely.ops import transform
 from shapely.geometry import mapping
 from shapely.geometry.base import BaseGeometry
+from shapely.ops import transform
 
 
 class GeoAgent(Agent):
     """Base class for a geo model agent."""
 
-    def __init__(self, unique_id, model, geometry):
+    def __init__(self, unique_id, model, geometry, crs):
         """Create a new agent.
 
         unique_id: Id of agent. Uniqueness is not guaranteed!
-        model: The associated model of the agent
+        model: The associated model of the agent.
         geometry: A Shapely object representing the geometry
             of the agent
+        crs: Coordinate reference system.
         """
         self.unique_id = unique_id
         self.model = model
         self.geometry = geometry
+        self.crs = pyproj.CRS.from_user_input(crs)
+
+    def to_crs(self, crs):
+        if self.crs is None:
+            raise TypeError("Need a valid crs to transform from.")
+        if crs is None:
+            raise TypeError("Need a valid crs to transform to.")
+
+        if not self.crs.is_exact_same(crs):
+            transformer = pyproj.Transformer.from_crs(
+                crs_from=self.crs, crs_to=crs, always_xy=True
+            )
+            self.geometry = self.get_transformed_geometry(transformer)
+            self.crs = crs
 
     def get_transformed_geometry(self, transformer):
         """
@@ -58,23 +74,33 @@ class GeoAgent(Agent):
 class AgentCreator:
     """Create GeoAgents from files, GeoDataFrames, GeoJSON or Shapely objects."""
 
-    def __init__(self, agent_class, agent_kwargs, crs="epsg:3857"):
+    def __init__(self, agent_class, model=None, crs=None, agent_kwargs=None):
         """Define the agent_class and required agent_kwargs.
 
         Args:
             agent_class: Reference to a GeoAgent class
             agent_kwargs: Dictionary with required agent creation arguments.
                 Must at least include 'model' and must NOT include unique_id
-            crs: Coordinate reference system. If geometries are loaded from
-                file they will be converted into this crs automatically.
+            crs: Coordinate reference system. Default to None, and the crs
+                from the file/GeoDataFrame/GeoJSON will be used. Otherwise,
+                geometries are converted into this crs automatically.
         """
-        if "unique_id" in agent_kwargs:
+        if agent_kwargs and "unique_id" in agent_kwargs:
             agent_kwargs.remove("unique_id")
             warnings.warn("Unique_id should not be in the agent_kwargs")
 
         self.agent_class = agent_class
-        self.agent_kwargs = agent_kwargs
+        self.model = model
         self.crs = crs
+        self.agent_kwargs = agent_kwargs if agent_kwargs else {}
+
+    @property
+    def crs(self):
+        return self._crs
+
+    @crs.setter
+    def crs(self, crs):
+        self._crs = pyproj.CRS.from_user_input(crs) if crs else None
 
     def create_agent(self, geometry, unique_id):
         """Create a single agent from a geometry and a unique_id
@@ -84,8 +110,17 @@ class AgentCreator:
         if not isinstance(geometry, BaseGeometry):
             raise TypeError("Geometry must be a Shapely Geometry")
 
+        if not self.crs:
+            raise TypeError(
+                f"Unable to set CRS for {self.agent_class.__name__} due to empty CRS in {self.__class__.__name__}"
+            )
+
         new_agent = self.agent_class(
-            unique_id=unique_id, geometry=geometry, **self.agent_kwargs
+            unique_id=unique_id,
+            model=self.model,
+            geometry=geometry,
+            crs=self.crs,
+            **self.agent_kwargs,
         )
 
         return new_agent
@@ -94,6 +129,7 @@ class AgentCreator:
         """Create a list of agents from a GeoDataFrame.
 
         Args:
+            gdf: The GeoDataFrame where agents are created from.
             unique_id: Column to use for the unique_id.
                 If "index" use the GeoDataFrame index
             set_attributes: Set agent attributes from GeoDataFrame columns.
@@ -102,10 +138,21 @@ class AgentCreator:
         if unique_id != "index":
             gdf = gdf.set_index(unique_id)
 
-        gdf = gdf.to_crs(self.crs)
+        if self.crs:
+            if gdf.crs:
+                gdf.to_crs(self.crs, inplace=True)
+            else:
+                gdf.set_crs(self.crs, inplace=True)
+        else:
+            if gdf.crs:
+                self.crs = gdf.crs
+            else:
+                raise TypeError(
+                    f"Unable to set CRS for {self.agent_class.__name__} due to empty CRS in both "
+                    f"{self.__class__.__name__} and {gdf.__class__.__name__}."
+                )
 
         agents = list()
-
         for index, row in gdf.iterrows():
             geometry = row[gdf.geometry.name]
             new_agent = self.create_agent(geometry=geometry, unique_id=index)
@@ -115,6 +162,7 @@ class AgentCreator:
                     if not col == gdf.geometry.name:
                         setattr(new_agent, col, row[col])
             agents.append(new_agent)
+
         return agents
 
     def from_file(self, filename, unique_id="index", set_attributes=True):
@@ -132,11 +180,11 @@ class AgentCreator:
         return agents
 
     def from_GeoJSON(self, GeoJSON, unique_id="index", set_attributes=True):
-        """Create agents from a GeoJSON object or string.
+        """Create agents from a GeoJSON object or string. CRS is set to epsg:4326.
 
         Args:
             GeoJSON: The GeoJSON object or string
-            unique_id: The fieldfeature name of the data to use as the agents unique_id
+            unique_id: The field name of the data to use as the agents unique_id
             set_attributes: Set attributes from features
         """
         if type(GeoJSON) is str:
@@ -145,6 +193,7 @@ class AgentCreator:
             gj = GeoJSON
 
         gdf = gpd.GeoDataFrame.from_features(gj)
+        # epsg:4326 is the CRS for all GeoJSON: https://datatracker.ietf.org/doc/html/rfc7946#section-4
         gdf.crs = "epsg:4326"
         agents = self.from_GeoDataFrame(
             gdf, unique_id=unique_id, set_attributes=set_attributes

--- a/mesa_geo/geoagent.py
+++ b/mesa_geo/geoagent.py
@@ -62,7 +62,7 @@ class GeoAgent(Agent):
         properties = dict(vars(self))
         properties["model"] = str(self.model)
         geometry = properties.pop("geometry")
-        geometry = transform(self.model.space.Transformer.transform, geometry)
+        geometry = transform(self.model.space.transformer.transform, geometry)
 
         return {
             "type": "Feature",

--- a/mesa_geo/visualization/modules/MapVisualization.py
+++ b/mesa_geo/visualization/modules/MapVisualization.py
@@ -23,7 +23,7 @@ class MapModule(VisualizationElement):
         feature_collection = {"type": "FeatureCollection", "features": []}
         for agent in model.space.agents:
             transformed_geometry = agent.get_transformed_geometry(
-                model.space.Transformer
+                model.space.transformer
             )
             properties = self.portrayal_method(agent) if self.portrayal_method else {}
             feature_collection["features"].append(

--- a/tests/test_AgentCreator.py
+++ b/tests/test_AgentCreator.py
@@ -1,7 +1,7 @@
 import unittest
 
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
 from shapely.geometry import Point
 
 from mesa_geo.geoagent import GeoAgent, AgentCreator
@@ -9,8 +9,10 @@ from mesa_geo.geoagent import GeoAgent, AgentCreator
 
 class TestAgentCreator(unittest.TestCase):
     def setUp(self) -> None:
-        self.agent_creator = AgentCreator(
-            agent_class=GeoAgent, agent_kwargs={"model": None}
+        self.agent_creator_without_crs = AgentCreator(agent_class=GeoAgent)
+        self.agent_creator_with_crs = AgentCreator(
+            agent_class=GeoAgent,
+            crs="epsg:3857",
         )
         self.df = pd.DataFrame(
             {
@@ -21,14 +23,44 @@ class TestAgentCreator(unittest.TestCase):
             }
         )
 
+        self.geojson_str = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "id": "0",
+                    "type": "Feature",
+                    "properties": {"col1": "name1"},
+                    "geometry": {"type": "Point", "coordinates": (1.0, 2.0)},
+                    "bbox": (1.0, 2.0, 1.0, 2.0),
+                },
+                {
+                    "id": "1",
+                    "type": "Feature",
+                    "properties": {"col1": "name2"},
+                    "geometry": {"type": "Point", "coordinates": (2.0, 1.0)},
+                    "bbox": (2.0, 1.0, 2.0, 1.0),
+                },
+            ],
+            "bbox": (1.0, 1.0, 2.0, 2.0),
+        }
+
     def tearDown(self) -> None:
         pass
 
-    def test_create_agent(self):
-        agent = self.agent_creator.create_agent(geometry=Point(1, 1), unique_id=0)
+    def test_create_agent_with_crs(self):
+        agent = self.agent_creator_with_crs.create_agent(
+            geometry=Point(1, 1), unique_id=0
+        )
         self.assertIsInstance(agent, GeoAgent)
         self.assertEqual(agent.geometry, Point(1, 1))
         self.assertIsNone(agent.model)
+        self.assertEqual(agent.crs, self.agent_creator_with_crs.crs)
+
+    def test_create_agent_without_crs(self):
+        with self.assertRaises(TypeError):
+            self.agent_creator_without_crs.create_agent(
+                geometry=Point(1, 1), unique_id=0
+            )
 
     def test_from_GeoDataFrame_with_default_geometry_name(self):
         gdf = gpd.GeoDataFrame(
@@ -36,13 +68,14 @@ class TestAgentCreator(unittest.TestCase):
             geometry=gpd.points_from_xy(self.df.Longitude, self.df.Latitude),
             crs="epsg:3857",
         )
-        agents = self.agent_creator.from_GeoDataFrame(gdf)
+        agents = self.agent_creator_without_crs.from_GeoDataFrame(gdf)
 
         self.assertEqual(len(agents), 5)
 
         self.assertEqual(agents[0].City, "Buenos Aires")
         self.assertEqual(agents[0].Country, "Argentina")
         self.assertEqual(agents[0].geometry, Point(-58.66, -34.58))
+        self.assertEqual(agents[0].crs, gdf.crs)
 
     def test_from_GeoDataFrame_with_custom_geometry_name(self):
         gdf = gpd.GeoDataFrame(
@@ -52,7 +85,7 @@ class TestAgentCreator(unittest.TestCase):
         )
         gdf.rename_geometry("custom_name", inplace=True)
 
-        agents = self.agent_creator.from_GeoDataFrame(gdf)
+        agents = self.agent_creator_without_crs.from_GeoDataFrame(gdf)
 
         self.assertEqual(len(agents), 5)
 
@@ -60,3 +93,77 @@ class TestAgentCreator(unittest.TestCase):
         self.assertEqual(agents[0].Country, "Argentina")
         self.assertEqual(agents[0].geometry, Point(-58.66, -34.58))
         self.assertFalse(hasattr(agents[0], "custom_name"))
+        self.assertEqual(agents[0].crs, gdf.crs)
+
+    def test_from_GeoJSON_and_agent_creator_without_crs(self):
+        agents = self.agent_creator_without_crs.from_GeoJSON(self.geojson_str)
+
+        self.assertEqual(len(agents), 2)
+
+        self.assertEqual(agents[0].unique_id, 0)
+        self.assertEqual(agents[0].col1, "name1")
+        self.assertEqual(agents[0].geometry, Point(1.0, 2.0))
+        self.assertEqual(agents[0].crs, "epsg:4326")
+
+        self.assertEqual(agents[1].unique_id, 1)
+        self.assertEqual(agents[1].col1, "name2")
+        self.assertEqual(agents[1].geometry, Point(2.0, 1.0))
+        self.assertEqual(agents[1].crs, "epsg:4326")
+
+    def test_from_GeoJSON_and_agent_creator_with_crs(self):
+        agents = self.agent_creator_with_crs.from_GeoJSON(self.geojson_str)
+
+        self.assertEqual(len(agents), 2)
+
+        self.assertEqual(agents[0].unique_id, 0)
+        self.assertEqual(agents[0].col1, "name1")
+        self.assertTrue(
+            agents[0].geometry.equals_exact(
+                Point(111319.49079327357, 222684.20850554403), tolerance=1e-6
+            )
+        )
+        self.assertEqual(agents[0].crs, self.agent_creator_with_crs.crs)
+
+        self.assertEqual(agents[1].unique_id, 1)
+        self.assertEqual(agents[1].col1, "name2")
+        self.assertTrue(
+            agents[1].geometry.equals_exact(
+                Point(222638.98158654713, 111325.14286638508), tolerance=1e-6
+            )
+        )
+        self.assertEqual(agents[1].crs, self.agent_creator_with_crs.crs)
+
+    def test_from_GeoDataFrame_without_crs_and_agent_creator_without_crs(self):
+        gdf = gpd.GeoDataFrame(
+            self.df, geometry=gpd.points_from_xy(self.df.Longitude, self.df.Latitude)
+        )
+        with self.assertRaises(TypeError):
+            self.agent_creator_without_crs.from_GeoDataFrame(gdf)
+
+    def test_from_GeoDataFrame_without_crs_and_agent_creator_with_crs(self):
+        gdf = gpd.GeoDataFrame(
+            self.df, geometry=gpd.points_from_xy(self.df.Longitude, self.df.Latitude)
+        )
+        agents = self.agent_creator_with_crs.from_GeoDataFrame(gdf)
+
+        self.assertEqual(len(agents), 5)
+
+        self.assertEqual(agents[0].City, "Buenos Aires")
+        self.assertEqual(agents[0].Country, "Argentina")
+        self.assertEqual(agents[0].geometry, Point(-58.66, -34.58))
+        self.assertEqual(agents[0].crs, self.agent_creator_with_crs.crs)
+
+    def test_from_GeoDataFrame_with_crs_and_agent_creator_without_crs(self):
+        gdf = gpd.GeoDataFrame(
+            self.df,
+            geometry=gpd.points_from_xy(self.df.Longitude, self.df.Latitude),
+            crs="epsg:2263",
+        )
+        agents = self.agent_creator_without_crs.from_GeoDataFrame(gdf)
+
+        self.assertEqual(len(agents), 5)
+
+        self.assertEqual(agents[0].City, "Buenos Aires")
+        self.assertEqual(agents[0].Country, "Argentina")
+        self.assertEqual(agents[0].geometry, Point(-58.66, -34.58))
+        self.assertEqual(agents[0].crs, gdf.crs)

--- a/tests/test_GeoSpace.py
+++ b/tests/test_GeoSpace.py
@@ -10,7 +10,8 @@ from shapely.geometry import Point
 class TestGeoSpace(unittest.TestCase):
     def setUp(self) -> None:
         self.agent_creator = AgentCreator(
-            agent_class=GeoAgent, agent_kwargs={"model": None}
+            agent_class=GeoAgent,
+            crs="epsg:3857",
         )
         self.geometries = [Point(1, 1)] * 7
         self.agents = [
@@ -20,15 +21,31 @@ class TestGeoSpace(unittest.TestCase):
             for geometry in self.geometries
         ]
         self.geo_space = GeoSpace()
+        self.geo_space_with_different_crs = GeoSpace(crs="epsg:2283")
 
     def tearDown(self) -> None:
         pass
 
-    def test_add_agents(self):
+    def test_add_agents_with_the_same_crs(self):
         self.assertEqual(len(self.geo_space.agents), 0)
         self.geo_space.add_agents(self.agents)
-
         self.assertEqual(len(self.geo_space.agents), len(self.agents))
+
+        for agent in self.geo_space.agents:
+            self.assertEqual(agent.crs, self.geo_space.crs)
+
+    def test_add_agents_with_different_crs(self):
+        self.assertEqual(len(self.geo_space_with_different_crs.agents), 0)
+        with self.assertRaises(ValueError):
+            self.geo_space_with_different_crs.add_agents(self.agents)
+
+        self.geo_space_with_different_crs.add_agents(self.agents, auto_convert_crs=True)
+        self.assertEqual(
+            len(self.geo_space_with_different_crs.agents), len(self.agents)
+        )
+
+        for agent in self.geo_space_with_different_crs.agents:
+            self.assertEqual(agent.crs, self.geo_space_with_different_crs.crs)
 
     def test_remove_agent(self):
         self.geo_space.add_agents(self.agents)

--- a/tests/test_MapModule.py
+++ b/tests/test_MapModule.py
@@ -13,7 +13,7 @@ class TestMapModule(unittest.TestCase):
         self.model = Model()
         self.model.space = GeoSpace()
         self.agent_creator = AgentCreator(
-            agent_class=GeoAgent, agent_kwargs={"model": self.model}
+            agent_class=GeoAgent, model=self.model, crs="epsg:3857"
         )
         self.geometries = [Point(1, 1)] * 7
         self.agents = [


### PR DESCRIPTION
Addresses https://github.com/projectmesa/mesa-geo/issues/49. With this PR:

1. Every `GeoAgent` object has its own `crs` attribute. (I tried to implement it as a class variable `CRS`, but it's hard to make sure that all geo agents of the same type are in sync with the same `CRS`.)
2. When `GeoAgent` is added into `GeoSpace`, its `crs` and `geometry` are converted to that of `GeoSpace`.
3. The default behavior of `AgentCreator` is to keep the `crs` from input data, be it from file, GeoJSON (assuming `epsg:4326`) or GeoDataFrame.
4. If `crs` is set in `AgentCreator`, then geometries will be converted from input data source to this defined `crs`.

To summarize the behavior of `AgentCreator` when creating geo agents from other data sources (file/GeoDataFrame/GeoJSON):

<table>
  <tbody>
    <tr>
      <td></td>
      <td><b>AgentCreator</b><br>(default crs=None)</td>
      <td><b>AgentCreator</b><br>(user defined crs)</td>
    </tr>
    <tr>
      <td><b>Data Source</b><br>(with crs)</td>
      <td>Same as data source</td>
      <td>Converted to AgentCreator crs</td>
    </tr>
    <tr>
      <td><b>Data Source</b><br>(missing crs)</td>
      <td>Raises Exception</td>
      <td>Set to AgentCreator crs</td>
    </tr>
  </tbody>
</table>

@rht @Corvince @tpike3 Please feel free to suggest alternative approaches : )