### PR TITLE
remove version number from leaflet filenames

### DIFF
--- a/mesa_geo/visualization/modules/MapVisualization.py
+++ b/mesa_geo/visualization/modules/MapVisualization.py
@@ -5,7 +5,7 @@ from mesa.visualization.ModularVisualization import VisualizationElement
 class MapModule(VisualizationElement):
     """A MapModule for Leaflet maps."""
 
-    package_includes = ["external/leaflet-1.8.0.js", "MapModule.js"]
+    package_includes = ["external/leaflet.js", "MapModule.js"]
     local_includes = []
 
     def __init__(

--- a/mesa_geo/visualization/templates/modular_template.html
+++ b/mesa_geo/visualization/templates/modular_template.html
@@ -6,7 +6,7 @@
     <link href="/static/css/bootstrap-switch.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/bootstrap-slider.min.css" type="text/css" rel="stylesheet" />
     <link href="/static/css/visualization.css" type="text/css" rel="stylesheet" />
-    <link href="/static/css/external/leaflet-1.8.0.css" type="text/css" rel="stylesheet" />
+    <link href="/static/css/external/leaflet.css" type="text/css" rel="stylesheet" />
 
 	<!-- This is the Tornado template for the Modular Visualization. The Javascript code opens a WebSocket connection to
 	the server (the port is set via the template). On every step, it receives inputs, one per module, and sends


### PR DESCRIPTION
This PR:

- removes the version number from leaflet dependency filenames
- skips downloading from the internet if file already exists and the existing file has the required hash