### PR TITLE
Implement RasterLayer

### DIFF
--- a/mesa_geo/__init__.py
+++ b/mesa_geo/__init__.py
@@ -6,9 +6,10 @@ Core Objects: GeoSpace, GeoAgent
 import datetime
 
 from mesa_geo.geoagent import GeoAgent, AgentCreator
-from mesa_geo.geospace import GeoSpace, ImageLayer
+from mesa_geo.geospace import GeoSpace
+from mesa_geo.raster_layers import ImageLayer, Cell, RasterLayer
 
-__all__ = ["GeoSpace", "GeoAgent", "AgentCreator", "ImageLayer"]
+__all__ = ["GeoSpace", "GeoAgent", "AgentCreator", "ImageLayer", "Cell", "RasterLayer"]
 
 __title__ = "Mesa-Geo"
 __version__ = "0.2.0"

--- a/mesa_geo/geo_base.py
+++ b/mesa_geo/geo_base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+
+import numpy as np
+import pyproj
+
+
+class GeoBase:
+    _crs: pyproj.CRS | None
+
+    def __init__(self, crs=None):
+        self.crs = crs
+
+    @property
+    @abstractmethod
+    def total_bounds(self) -> np.ndarray | None:
+        raise NotImplementedError
+
+    @property
+    def crs(self) -> pyproj.CRS | None:
+        return self._crs
+
+    @crs.setter
+    def crs(self, crs):
+        self._crs = pyproj.CRS.from_user_input(crs) if crs else None
+
+    @abstractmethod
+    def to_crs(self, crs, inplace=False) -> GeoBase | None:
+        raise NotImplementedError
+
+    def _to_crs_check(self, crs) -> None:
+        if self.crs is None:
+            raise TypeError("Need a valid crs to transform from.")
+        if crs is None:
+            raise TypeError("Need a valid crs to transform to.")

--- a/mesa_geo/geospace.py
+++ b/mesa_geo/geospace.py
@@ -1,30 +1,22 @@
 from __future__ import annotations
 
-from typing import List, Tuple
-import copy
-import math
 import warnings
+from typing import List
 
+import geopandas as gpd
+import numpy as np
 import pyproj
 from libpysal import weights
 from rtree import index
 from shapely.geometry import Point
 from shapely.prepared import prep
-import numpy as np
-import geopandas as gpd
-from affine import Affine
-import rasterio as rio
-from rasterio.warp import (
-    calculate_default_transform,
-    transform_bounds,
-    reproject,
-    Resampling,
-)
 
+from mesa_geo.geo_base import GeoBase
 from mesa_geo.geoagent import GeoAgent
+from mesa_geo.raster_layers import ImageLayer, RasterLayer
 
 
-class GeoSpace:
+class GeoSpace(GeoBase):
     def __init__(self, crs="epsg:3857", *, warn_crs_conversion=True):
         """Create a GeoSpace for GIS enabled mesa modeling.
 
@@ -46,7 +38,7 @@ class GeoSpace:
                          epsg:4326. Mainly used for GeoJSON serialization.
             agents: List of all agents in the GeoSpace.
             layers: List of all layers in the GeoSpace.
-            bounds: Bounds of the GeoSpace in [min_x, min_y, max_x, max_y] format.
+            total_bounds: Bounds of the GeoSpace in [min_x, min_y, max_x, max_y] format.
 
         Methods:
             add_agents: Add a list or a single GeoAgent.
@@ -57,23 +49,34 @@ class GeoSpace:
             get_intersecting_agents: Returns list of agents that intersect
             get_relation: Return a list of related agents
             get_neighbors_within_distance: Return a list of agents within `distance` of `agent`
-            add_layer: Add a ImageLayer or a geopandas.GeoDataFrame
+            add_layer: Add an ImageLayer, RasterLayer or a geopandas.GeoDataFrame
         """
-        self._crs = pyproj.CRS.from_user_input(crs)
+        super().__init__(crs)
         self._transformer = pyproj.Transformer.from_crs(
             crs_from=self.crs, crs_to="epsg:4326", always_xy=True
         )
         self.warn_crs_conversion = warn_crs_conversion
         self._agent_layer = _AgentLayer()
         self._static_layers = []
-        self._bounds = []  # [min_x, min_y, max_x, max_y]
+        self._total_bounds = None  # [min_x, min_y, max_x, max_y]
 
-    @property
-    def crs(self):
-        """
-        Return the coordinate reference system of the GeoSpace.
-        """
-        return self._crs
+    def to_crs(self, crs, inplace=False) -> GeoSpace | None:
+        super()._to_crs_check(crs)
+
+        if inplace:
+            for agent in self.agents:
+                agent.to_crs(crs, inplace=True)
+            for layer in self.layers:
+                layer.to_crs(crs, inplace=True)
+        else:
+            geospace = GeoSpace(
+                crs=self.crs.to_string(), warn_crs_conversion=self.warn_crs_conversion
+            )
+            for agent in self.agents:
+                geospace.add_agents(agent.to_crs(crs, inplace=False))
+            for layer in self.layers:
+                geospace.add_layer(layer.to_crs(crs, inplace=False))
+            return geospace
 
     @property
     def transformer(self):
@@ -91,29 +94,31 @@ class GeoSpace:
         return self._agent_layer.agents
 
     @property
-    def layers(self) -> List[ImageLayer | gpd.GeoDataFrame]:
+    def layers(self) -> List[ImageLayer | RasterLayer | gpd.GeoDataFrame]:
         """
         Return a list of all layers in the Geospace.
         """
         return self._static_layers
 
     @property
-    def bounds(self):
+    def total_bounds(self) -> np.ndarray | None:
         """
         Return the bounds of the GeoSpace in [min_x, min_y, max_x, max_y] format.
         """
-        return self._bounds
+        return self._total_bounds
 
-    def update_bounds(self, new_bounds: List[float]) -> None:
+    def _update_bounds(self, new_bounds: np.ndarray) -> None:
         if new_bounds:
-            if self._bounds:
-                new_min_x = min(self.bounds[0], new_bounds[0])
-                new_min_y = min(self.bounds[1], new_bounds[1])
-                new_max_x = max(self.bounds[2], new_bounds[2])
-                new_max_y = max(self.bounds[3], new_bounds[3])
-                self._bounds = [new_min_x, new_min_y, new_max_x, new_max_y]
+            if self._total_bounds is not None:
+                new_min_x = min(self.total_bounds[0], new_bounds[0])
+                new_min_y = min(self.total_bounds[1], new_bounds[1])
+                new_max_x = max(self.total_bounds[2], new_bounds[2])
+                new_max_y = max(self.total_bounds[3], new_bounds[3])
+                self._total_bounds = np.array(
+                    [new_min_x, new_min_y, new_max_x, new_max_y]
+                )
             else:
-                self._bounds = new_bounds
+                self._total_bounds = new_bounds
 
     @property
     def __geo_interface__(self):
@@ -121,11 +126,11 @@ class GeoSpace:
         features = [a.__geo_interface__() for a in self.agents]
         return {"type": "FeatureCollection", "features": features}
 
-    def add_layer(self, layer: ImageLayer | gpd.GeoDataFrame) -> None:
+    def add_layer(self, layer: ImageLayer | RasterLayer | gpd.GeoDataFrame) -> None:
         """Add a layer to the Geospace.
 
         Args:
-            layer: A ImageLayer or a geopandas.GeoDataFrame, to be added into GeoSpace.
+            layer: An ImageLayer, RasterLayer or a geopandas.GeoDataFrame, to be added into GeoSpace.
         """
         if not self.crs.is_exact_same(layer.crs):
             if self.warn_crs_conversion:
@@ -136,10 +141,7 @@ class GeoSpace:
                     "to `False` to suppress this warning message."
                 )
             layer.to_crs(self.crs, inplace=True)
-        layer_bounds = (
-            layer.bounds if isinstance(layer, ImageLayer) else list(layer.total_bounds)
-        )
-        self.update_bounds(layer_bounds)
+        self._update_bounds(layer.total_bounds)
         self._static_layers.append(layer)
 
     def _check_agent(self, agent):
@@ -152,7 +154,7 @@ class GeoSpace:
                         "Please check your crs settings if this is unintended, or set `GeoSpace.warn_crs_conversion` "
                         "to `False` to suppress this warning message."
                     )
-                agent.to_crs(self.crs)
+                agent.to_crs(self.crs, inplace=True)
         else:
             raise AttributeError("GeoAgents must have a geometry attribute")
 
@@ -175,7 +177,7 @@ class GeoSpace:
             for agent in agents:
                 self._check_agent(agent)
         self._agent_layer.add_agents(agents)
-        self.update_bounds(new_bounds=self._agent_layer.bounds)
+        self._update_bounds(new_bounds=self._agent_layer.total_bounds)
 
     def _recreate_rtree(self, new_agents=None):
         """Create a new rtree index from agents geometries."""
@@ -230,7 +232,7 @@ class _AgentLayer:
 
     Properties:
         idx: R-tree index for fast spatial queries
-        bounds: Bounds of the layer in [min_x, min_y, max_x, max_y] format
+        total_bounds: Bounds of the layer in [min_x, min_y, max_x, max_y] format
         agents: List of all agents in the layer
 
     Methods:
@@ -256,7 +258,7 @@ class _AgentLayer:
         return list(self.idx.agents.values())
 
     @property
-    def bounds(self):
+    def total_bounds(self):
         return self.idx.get_bounds(coordinate_interleaved=True)
 
     def _get_rtree_intersections(self, geometry):
@@ -366,116 +368,3 @@ class _AgentLayer:
         neighbors_idx = self._neighborhood.neighbors[idx]
         neighbors = [self.agents[i] for i in neighbors_idx]
         return neighbors
-
-
-class ImageLayer:
-    _values: np.ndarray
-    _crs: pyproj.CRS | None
-    _transform: Affine
-    _bounds: List[float]  # [min_x, min_y, max_x, max_y]
-
-    def __init__(self, values, crs, bounds):
-        self._values = values
-        self.crs = crs
-        self.bounds = bounds
-
-    @property
-    def shape(self):
-        return self.values.shape
-
-    @property
-    def resolution(self) -> Tuple[float, float]:
-        """
-        Returns the (width, height) of a pixel in the units of CRS.
-        """
-        a, b, _, d, e, _, _, _, _ = self.transform
-        return math.sqrt(a**2 + d**2), math.sqrt(b**2 + e**2)
-
-    @property
-    def values(self) -> np.ndarray:
-        return self._values
-
-    @values.setter
-    def values(self, values: np.ndarray) -> None:
-        self._values = values
-        self._update_transform()
-
-    @property
-    def transform(self) -> Affine:
-        return self._transform
-
-    @property
-    def bounds(self) -> List[float]:
-        return self._bounds
-
-    @bounds.setter
-    def bounds(self, bounds: List[float]) -> None:
-        self._bounds = bounds
-        self._update_transform()
-
-    def _update_transform(self) -> None:
-        self._transform = rio.transform.from_bounds(
-            *self.bounds, width=self.shape[2], height=self.shape[1]
-        )
-
-    @property
-    def crs(self) -> pyproj.CRS | None:
-        return self._crs
-
-    @crs.setter
-    def crs(self, crs) -> None:
-        self._crs = pyproj.CRS.from_user_input(crs) if crs else None
-
-    def to_crs(self, crs, inplace=False) -> ImageLayer | None:
-        if self.crs is None:
-            raise TypeError("Need a valid crs to transform from.")
-        if crs is None:
-            raise TypeError("Need a valid crs to transform to.")
-
-        layer = self if inplace else copy.copy(self)
-
-        src_crs = rio.crs.CRS.from_user_input(layer.crs)
-        dst_crs = rio.crs.CRS.from_user_input(crs)
-        if not layer.crs.is_exact_same(crs):
-            num_bands, src_height, src_width = layer.shape
-            transform, dst_width, dst_height = calculate_default_transform(
-                src_crs,
-                dst_crs,
-                src_width,
-                src_height,
-                *layer.bounds,
-            )
-            dst = np.empty(shape=(num_bands, dst_height, dst_width))
-            for i, band in enumerate(layer.values):
-                reproject(
-                    source=band,
-                    destination=dst[i],
-                    src_transform=layer.transform,
-                    src_crs=src_crs,
-                    dst_transform=transform,
-                    dst_crs=dst_crs,
-                    resampling=Resampling.nearest,
-                )
-            layer._bounds = [*transform_bounds(src_crs, dst_crs, *layer.bounds)]
-            layer._values = dst
-            layer.crs = crs
-            layer._transform = transform
-        if not inplace:
-            return layer
-
-    @classmethod
-    def from_file(cls, raster_file: str) -> ImageLayer:
-        with rio.open(raster_file, "r") as dataset:
-            values = dataset.read()
-            bounds = [
-                dataset.bounds.left,
-                dataset.bounds.bottom,
-                dataset.bounds.right,
-                dataset.bounds.top,
-            ]
-            obj = cls(values=values, crs=dataset.crs, bounds=bounds)
-            obj._transform = dataset.transform
-            return obj
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(crs={self.crs}, bounds={self.bounds}, values={repr(self.values)})"

--- a/mesa_geo/raster_layers.py
+++ b/mesa_geo/raster_layers.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+import copy
+import itertools
+import math
+from typing import (
+    Tuple,
+    List,
+    Dict,
+    Any,
+    Set,
+    cast,
+    overload,
+    Sequence,
+    Iterator,
+    Iterable,
+)
+
+import numpy as np
+import rasterio as rio
+from affine import Affine
+from mesa.agent import Agent
+from mesa.space import Coordinate, accept_tuple_argument
+from rasterio.warp import (
+    calculate_default_transform,
+    transform_bounds,
+    reproject,
+    Resampling,
+)
+
+from mesa_geo.geo_base import GeoBase
+
+
+class RasterBase(GeoBase):
+    """
+    Base class for raster layers.
+    """
+
+    _width: int
+    _height: int
+    _transform: Affine
+    _total_bounds: np.ndarray  # [min_x, min_y, max_x, max_y]
+
+    def __init__(self, width, height, crs, total_bounds):
+        super().__init__(crs)
+        self._width = width
+        self._height = height
+        self._total_bounds = total_bounds
+        self._update_transform()
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @width.setter
+    def width(self, width: int) -> None:
+        self._width = width
+        self._update_transform()
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+    @height.setter
+    def height(self, height: int) -> None:
+        self._height = height
+        self._update_transform()
+
+    @property
+    def total_bounds(self) -> np.ndarray:
+        return self._total_bounds
+
+    @total_bounds.setter
+    def total_bounds(self, total_bounds: np.ndarray) -> None:
+        self._total_bounds = total_bounds
+        self._update_transform()
+
+    @property
+    def transform(self) -> Affine:
+        return self._transform
+
+    @property
+    def resolution(self) -> Tuple[float, float]:
+        """
+        Returns the (width, height) of a cell in the units of CRS.
+        """
+        a, b, _, d, e, _, _, _, _ = self.transform
+        return math.sqrt(a**2 + d**2), math.sqrt(b**2 + e**2)
+
+    def _update_transform(self) -> None:
+        self._transform = rio.transform.from_bounds(
+            *self.total_bounds, width=self.width, height=self.height
+        )
+
+    def to_crs(self, crs, inplace=False) -> RasterBase | None:
+        raise NotImplementedError
+
+    def out_of_bounds(self, pos: Coordinate) -> bool:
+        """Determines whether position is off the grid."""
+        x, y = pos
+        return x < 0 or x >= self.width or y < 0 or y >= self.height
+
+
+class Cell(Agent):
+    """
+    Cells are containers of raster attributes, and are building blocks of `RasterLayer`.
+    """
+
+    pos: Coordinate | None  # (x, y), origin is at lower left corner of the grid
+    indices: Coordinate | None  # (row, col), origin is at upper left corner of the grid
+
+    def __init__(self, pos=None, indices=None):
+        super().__init__(None, None)
+        self.pos = pos
+        self.indices = indices
+
+    def step(self):
+        pass
+
+
+class RasterLayer(RasterBase):
+    """
+    Some methods in `RasterLayer` are copied from `mesa.space.Grid`, including:
+
+    __getitem__
+    __iter__
+    coord_iter
+    iter_neighborhood
+    get_neighborhood
+    iter_neighbors
+    get_neighbors  # copied and renamed to `get_neighboring_cells`
+    out_of_bounds  # copied into `RasterBase`
+    iter_cell_list_contents
+    get_cell_list_contents
+
+    Methods from `mesa.space.Grid` that are not copied over:
+
+    torus_adj
+    neighbor_iter
+    move_agent
+    place_agent
+    _place_agent
+    remove_agent
+    is_cell_empty
+    move_to_empty
+    find_empty
+    exists_empty_cells
+
+    Another difference is that `mesa.space.Grid` has `self.grid: List[List[Agent | None]]`,
+    whereas it is `self.cells: List[List[Cell]]` here in `RasterLayer`.
+    """
+
+    cells: List[List[Cell]]
+    _neighborhood_cache: Dict[Any, List[Coordinate]]
+
+    def __init__(self, width, height, crs, total_bounds, cell_cls=Cell):
+        super().__init__(width, height, crs, total_bounds)
+        self.cell_cls = cell_cls
+        self.cells = []
+        for x in range(self.width):
+            col: List[cell_cls] = []
+            for y in range(self.height):
+                row_idx, col_idx = self.height - y - 1, x
+                col.append(self.cell_cls(pos=(x, y), indices=(row_idx, col_idx)))
+            self.cells.append(col)
+
+        self._neighborhood_cache = {}
+
+    @overload
+    def __getitem__(self, index: int) -> List[Cell]:
+        ...
+
+    @overload
+    def __getitem__(self, index: Tuple[int | slice, int | slice]) -> Cell | List[Cell]:
+        ...
+
+    @overload
+    def __getitem__(self, index: Sequence[Coordinate]) -> List[Cell]:
+        ...
+
+    def __getitem__(
+        self, index: int | Sequence[Coordinate] | Tuple[int | slice, int | slice]
+    ) -> Cell | List[Cell]:
+        """Access contents from the grid."""
+
+        if isinstance(index, int):
+            # cells[x]
+            return self.cells[index]
+
+        if isinstance(index[0], tuple):
+            # cells[(x1, y1), (x2, y2)]
+            index = cast(Sequence[Coordinate], index)
+
+            cells = []
+            for pos in index:
+                x1, y1 = pos
+                cells.append(self.cells[x1][y1])
+            return cells
+
+        x, y = index
+
+        if isinstance(x, int) and isinstance(y, int):
+            # cells[x, y]
+            x, y = cast(Coordinate, index)
+            return self.cells[x][y]
+
+        if isinstance(x, int):
+            # cells[x, :]
+            x = slice(x, x + 1)
+
+        if isinstance(y, int):
+            # grid[:, y]
+            y = slice(y, y + 1)
+
+        # cells[:, :]
+        x, y = (cast(slice, x), cast(slice, y))
+        cells = []
+        for rows in self.cells[x]:
+            for cell in rows[y]:
+                cells.append(cell)
+        return cells
+
+    def __iter__(self) -> Iterator[Cell]:
+        """Create an iterator that chains the rows of the cells together
+        as if it is one list"""
+        return itertools.chain(*self.cells)
+
+    def coord_iter(self) -> Iterator[Tuple[Cell, int, int]]:
+        """An iterator that returns coordinates as well as cell contents."""
+        for row in range(self.width):
+            for col in range(self.height):
+                yield self.cells[row][col], row, col  # cell, x, y
+
+    def apply_raster(self, data: np.ndarray, name: str = None) -> None:
+        assert data.shape == (1, self.height, self.width)
+        if name is None:
+            name = f"attribute_{len(self.cell_cls.__dict__)}"
+        for x in range(self.width):
+            for y in range(self.height):
+                setattr(self.cells[x][y], name, data[0, self.height - y - 1, x])
+
+    def iter_neighborhood(
+        self,
+        pos: Coordinate,
+        moore: bool,
+        include_center: bool = False,
+        radius: int = 1,
+    ) -> Iterator[Coordinate]:
+        """Return an iterator over cell coordinates that are in the
+        neighborhood of a certain point.
+        Args:
+            pos: Coordinate tuple for the neighborhood to get.
+            moore: If True, return Moore neighborhood
+                        (including diagonals)
+                   If False, return Von Neumann neighborhood
+                        (exclude diagonals)
+            include_center: If True, return the (x, y) cell as well.
+                            Otherwise, return surrounding cells only.
+            radius: radius, in cells, of neighborhood to get.
+        Returns:
+            A list of coordinate tuples representing the neighborhood. For
+            example with radius 1, it will return list with number of elements
+            equals at most 9 (8) if Moore, 5 (4) if Von Neumann (if not
+            including the center).
+        """
+        yield from self.get_neighborhood(pos, moore, include_center, radius)
+
+    def iter_neighbors(
+        self,
+        pos: Coordinate,
+        moore: bool,
+        include_center: bool = False,
+        radius: int = 1,
+    ) -> Iterator[Cell]:
+        """Return an iterator over neighbors to a certain point.
+        Args:
+            pos: Coordinates for the neighborhood to get.
+            moore: If True, return Moore neighborhood
+                    (including diagonals)
+                   If False, return Von Neumann neighborhood
+                     (exclude diagonals)
+            include_center: If True, return the (x, y) cell as well.
+                            Otherwise,
+                            return surrounding cells only.
+            radius: radius, in cells, of neighborhood to get.
+        Returns:
+            An iterator of non-None objects in the given neighborhood;
+            at most 9 if Moore, 5 if Von-Neumann
+            (8 and 4 if not including the center).
+        """
+        neighborhood = self.get_neighborhood(pos, moore, include_center, radius)
+        return self.iter_cell_list_contents(neighborhood)
+
+    @accept_tuple_argument
+    def iter_cell_list_contents(
+        self, cell_list: Iterable[Coordinate]
+    ) -> Iterator[Cell]:
+        """Returns an iterator of the contents of the cells
+        identified in cell_list.
+        Args:
+            cell_list: Array-like of (x, y) tuples, or single tuple.
+        Returns:
+            An iterator of the contents of the cells identified in cell_list
+        """
+        # Note: filter(None, iterator) filters away an element of iterator that
+        # is falsy. Hence, iter_cell_list_contents returns only non-empty
+        # contents.
+        return filter(None, (self.cells[x][y] for x, y in cell_list))
+
+    @accept_tuple_argument
+    def get_cell_list_contents(self, cell_list: Iterable[Coordinate]) -> List[Cell]:
+        """Returns a list of the contents of the cells
+        identified in cell_list.
+        Note: this method returns a list of cells.
+        Args:
+            cell_list: Array-like of (x, y) tuples, or single tuple.
+        Returns:
+            A list of the contents of the cells identified in cell_list
+        """
+        return list(self.iter_cell_list_contents(cell_list))
+
+    def get_neighborhood(
+        self,
+        pos: Coordinate,
+        moore: bool,
+        include_center: bool = False,
+        radius: int = 1,
+    ) -> List[Coordinate]:
+        cache_key = (pos, moore, include_center, radius)
+        neighborhood = self._neighborhood_cache.get(cache_key, None)
+
+        if neighborhood is None:
+            coordinates: Set[Coordinate] = set()
+
+            x, y = pos
+            for dy in range(-radius, radius + 1):
+                for dx in range(-radius, radius + 1):
+                    if dx == 0 and dy == 0 and not include_center:
+                        continue
+                    # Skip coordinates that are outside manhattan distance
+                    if not moore and abs(dx) + abs(dy) > radius:
+                        continue
+
+                    coord = (x + dx, y + dy)
+
+                    if self.out_of_bounds(coord):
+                        continue
+                    coordinates.add(coord)
+
+            neighborhood = sorted(coordinates)
+            self._neighborhood_cache[cache_key] = neighborhood
+
+        return neighborhood
+
+    def get_neighboring_cells(
+        self,
+        pos: Coordinate,
+        moore: bool,
+        include_center: bool = False,
+        radius: int = 1,
+    ) -> List[Cell]:
+        neighboring_cell_idx = self.get_neighborhood(pos, moore, include_center, radius)
+        return [self.cells[idx[0]][idx[1]] for idx in neighboring_cell_idx]
+
+    def to_crs(self, crs, inplace=False) -> RasterLayer | None:
+        super()._to_crs_check(crs)
+        layer = self if inplace else copy.copy(self)
+
+        src_crs = rio.crs.CRS.from_user_input(layer.crs)
+        dst_crs = rio.crs.CRS.from_user_input(crs)
+        if not layer.crs.is_exact_same(crs):
+            transform, dst_width, dst_height = calculate_default_transform(
+                src_crs,
+                dst_crs,
+                self.width,
+                self.height,
+                *layer.total_bounds,
+            )
+            layer._total_bounds = [
+                *transform_bounds(src_crs, dst_crs, *layer.total_bounds)
+            ]
+            layer.crs = crs
+            layer._transform = transform
+
+        if not inplace:
+            return layer
+
+    def to_image(self, colormap) -> ImageLayer:
+        """
+        Returns an ImageLayer colored by the provided colormap.
+        """
+        values = np.empty(shape=(4, self.height, self.width))
+        for cell in self:
+            row, col = cell.indices
+            values[:, row, col] = colormap(cell)
+        return ImageLayer(values=values, crs=self.crs, total_bounds=self.total_bounds)
+
+
+class ImageLayer(RasterBase):
+    _values: np.ndarray
+
+    def __init__(self, values, crs, total_bounds):
+        super().__init__(
+            width=values.shape[2],
+            height=values.shape[1],
+            crs=crs,
+            total_bounds=total_bounds,
+        )
+        self._values = values.copy()
+
+    @property
+    def values(self) -> np.ndarray:
+        return self._values
+
+    @values.setter
+    def values(self, values: np.ndarray) -> None:
+        self._values = values
+        self._width = values.shape[2]
+        self._height = values.shape[1]
+        self._update_transform()
+
+    def to_crs(self, crs, inplace=False) -> ImageLayer | None:
+        super()._to_crs_check(crs)
+        layer = self if inplace else copy.copy(self)
+
+        src_crs = rio.crs.CRS.from_user_input(layer.crs)
+        dst_crs = rio.crs.CRS.from_user_input(crs)
+        if not layer.crs.is_exact_same(crs):
+            num_bands, src_height, src_width = self.values.shape
+            transform, dst_width, dst_height = calculate_default_transform(
+                src_crs,
+                dst_crs,
+                src_width,
+                src_height,
+                *layer.total_bounds,
+            )
+            dst = np.empty(shape=(num_bands, dst_height, dst_width))
+            for i, band in enumerate(layer.values):
+                reproject(
+                    source=band,
+                    destination=dst[i],
+                    src_transform=layer.transform,
+                    src_crs=src_crs,
+                    dst_transform=transform,
+                    dst_crs=dst_crs,
+                    resampling=Resampling.nearest,
+                )
+            layer._total_bounds = [
+                *transform_bounds(src_crs, dst_crs, *layer.total_bounds)
+            ]
+            layer._values = dst
+            layer._height = layer._values.shape[1]
+            layer._width = layer._values.shape[2]
+            layer.crs = crs
+            layer._transform = transform
+        if not inplace:
+            return layer
+
+    @classmethod
+    def from_file(cls, raster_file: str) -> ImageLayer:
+        with rio.open(raster_file, "r") as dataset:
+            values = dataset.read()
+            total_bounds = [
+                dataset.bounds.left,
+                dataset.bounds.bottom,
+                dataset.bounds.right,
+                dataset.bounds.top,
+            ]
+            obj = cls(values=values, crs=dataset.crs, total_bounds=total_bounds)
+            obj._transform = dataset.transform
+            return obj
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(crs={self.crs}, total_bounds={self.total_bounds}, values={repr(self.values)})"

--- a/mesa_geo/visualization/templates/js/MapModule.js
+++ b/mesa_geo/visualization/templates/js/MapModule.js
@@ -17,13 +17,13 @@ var MapModule = function (view, zoom, map_width, map_height) {
 
     this.renderLayers = function (layers) {
         layers.rasters.forEach(function (layer) {
-            L.imageOverlay(layer, layers.bounds).addTo(Lmap)
+            L.imageOverlay(layer, layers.total_bounds).addTo(Lmap)
         })
         layers.vectors.forEach(function (layer) {
             L.geoJSON(layer).addTo(Lmap)
         })
-        // if (layers.bounds.length !== 0) {
-        //     Lmap.fitBounds(layers.bounds)
+        // if (layers.total_bounds.length !== 0) {
+        //     Lmap.fitBounds(layers.total_bounds)
         // }
     }
 

--- a/tests/test_GeoSpace.py
+++ b/tests/test_GeoSpace.py
@@ -23,7 +23,7 @@ class TestGeoSpace(unittest.TestCase):
         self.image_layer = ImageLayer(
             values=np.random.uniform(low=0, high=255, size=(3, 500, 500)),
             crs="epsg:4326",
-            bounds=[
+            total_bounds=[
                 -122.26638888878,
                 42.855833333,
                 -121.94972222209202,

--- a/tests/test_ImageLayer.py
+++ b/tests/test_ImageLayer.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import rasterio as rio
 
-from mesa_geo.geospace import ImageLayer
+from mesa_geo.raster_layers import ImageLayer
 
 
 class TestImageLayer(unittest.TestCase):
@@ -45,7 +45,7 @@ class TestImageLayer(unittest.TestCase):
         self.image_layer = ImageLayer(
             values=np.random.uniform(low=0, high=255, size=self.src_shape),
             crs=self.src_crs,
-            bounds=self.src_bounds,
+            total_bounds=self.src_bounds,
         )
 
     def tearDown(self) -> None:
@@ -54,29 +54,34 @@ class TestImageLayer(unittest.TestCase):
     def test_to_crs(self):
         transformed_image_layer = self.image_layer.to_crs(self.dst_crs)
         self.assertEqual(transformed_image_layer.crs, self.dst_crs)
-        self.assertEqual(transformed_image_layer.shape, self.dst_shape)
+        self.assertEqual(transformed_image_layer.height, self.dst_shape[1])
+        self.assertEqual(transformed_image_layer.width, self.dst_shape[2])
 
         self.assertTrue(
             transformed_image_layer.transform.almost_equals(self.dst_transform)
         )
-        np.testing.assert_almost_equal(transformed_image_layer.bounds, self.dst_bounds)
+        np.testing.assert_almost_equal(
+            transformed_image_layer.total_bounds, self.dst_bounds
+        )
         np.testing.assert_almost_equal(
             transformed_image_layer.resolution, self.dst_resolution
         )
 
         # no change to original layer
         self.assertEqual(self.image_layer.crs, self.src_crs)
-        self.assertEqual(self.image_layer.shape, self.src_shape)
+        self.assertEqual(self.image_layer.height, self.src_shape[1])
+        self.assertEqual(self.image_layer.width, self.src_shape[2])
 
         self.assertTrue(self.image_layer.transform.almost_equals(self.src_transform))
-        np.testing.assert_almost_equal(self.image_layer.bounds, self.src_bounds)
+        np.testing.assert_almost_equal(self.image_layer.total_bounds, self.src_bounds)
 
         np.testing.assert_almost_equal(self.image_layer.resolution, self.src_resolution)
 
     def test_to_crs_inplace(self):
         self.image_layer.to_crs(self.dst_crs, inplace=True)
         self.assertEqual(self.image_layer.crs, self.dst_crs)
-        self.assertEqual(self.image_layer.shape, self.dst_shape)
+        self.assertEqual(self.image_layer.height, self.dst_shape[1])
+        self.assertEqual(self.image_layer.width, self.dst_shape[2])
         self.assertTrue(self.image_layer.transform.almost_equals(self.dst_transform))
-        np.testing.assert_almost_equal(self.image_layer.bounds, self.dst_bounds)
+        np.testing.assert_almost_equal(self.image_layer.total_bounds, self.dst_bounds)
         np.testing.assert_almost_equal(self.image_layer.resolution, self.dst_resolution)

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -1,0 +1,88 @@
+import unittest
+
+import numpy as np
+
+from mesa_geo.raster_layers import RasterLayer
+
+
+class TestRasterLayer(unittest.TestCase):
+    def setUp(self) -> None:
+        self.raster_layer = RasterLayer(
+            width=2,
+            height=3,
+            crs="epsg:4326",
+            total_bounds=[
+                -122.26638888878,
+                42.855833333,
+                -121.94972222209202,
+                43.01472222189958,
+            ],
+        )
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_apple_raster(self):
+        raster_data = np.array([[[1, 2], [3, 4], [5, 6]]])
+        self.raster_layer.apply_raster(raster_data)
+        """
+        (x, y) coordinates:
+        (0, 2), (1, 2)
+        (0, 1), (1, 1)
+        (0, 0), (1, 0)
+
+        values:
+        [[[1, 2],
+          [3, 4],
+          [5, 6]]]
+        """
+        self.assertEqual(self.raster_layer.cells[0][1].attribute_5, 3)
+
+        self.raster_layer.apply_raster(raster_data, name="elevation")
+        self.assertEqual(self.raster_layer.cells[0][1].elevation, 3)
+
+    def test_get_min_cell(self):
+        self.raster_layer.apply_raster(
+            np.array([[[1, 2], [3, 4], [5, 6]]]), name="elevation"
+        )
+
+        min_cell = min(
+            self.raster_layer.get_neighboring_cells(pos=(0, 2), moore=True),
+            key=lambda cell: cell.elevation,
+        )
+        self.assertEqual(min_cell.pos, (1, 2))
+        self.assertEqual(min_cell.elevation, 2)
+
+        min_cell = min(
+            self.raster_layer.get_neighboring_cells(
+                pos=(0, 2), moore=True, include_center=True
+            ),
+            key=lambda cell: cell.elevation,
+        )
+        self.assertEqual(min_cell.pos, (0, 2))
+        self.assertEqual(min_cell.elevation, 1)
+
+        self.raster_layer.apply_raster(
+            np.array([[[1, 2], [3, 4], [5, 6]]]), name="water_level"
+        )
+        min_cell = min(
+            self.raster_layer.get_neighboring_cells(
+                pos=(0, 2), moore=True, include_center=True
+            ),
+            key=lambda cell: cell.elevation + cell.water_level,
+        )
+        self.assertEqual(min_cell.pos, (0, 2))
+        self.assertEqual(min_cell.elevation, 1)
+        self.assertEqual(min_cell.water_level, 1)
+
+    def test_get_max_cell(self):
+        self.raster_layer.apply_raster(
+            np.array([[[1, 2], [3, 4], [5, 6]]]), name="elevation"
+        )
+
+        max_cell = max(
+            self.raster_layer.get_neighboring_cells(pos=(0, 2), moore=True),
+            key=lambda cell: cell.elevation,
+        )
+        self.assertEqual(max_cell.pos, (1, 1))
+        self.assertEqual(max_cell.elevation, 4)


### PR DESCRIPTION
This PR is not yet ready, but I'd like to gather some feedbacks from you @rht @Corvince 

The classes now look like this:

```mermaid
classDiagram
GeoBase <|-- GeoAgent 
GeoBase <|-- GeoSpace
GeoAgent <-- GeoSpace: contains
GeoBase <|-- RasterBase
RasterBase <-- GeoSpace: contains
RasterBase <|-- ImageLayer
RasterBase <|-- RasterLayer
Cell <-- RasterLayer: contains
```

The main pending works are:

1. Visualization of `RasterLayer`

   Currently `RasterLayer` uses a portrayal method to map a `Cell` to a color, i.e., (r, g, b, a). But it would be better if the users can define the portrayal method to return a dict (similar to agent portrayal). And I'm not sure how this works with a range of colors. Example from NetLogo: [scale-color ](http://ccl.northwestern.edu/netlogo/docs/dict/scale-color.html).

2. ~~The `get_min_cell` and `get_max_cell` methods~~

   ~~Instead of the current implementation, I was thinking to have something more generic such as~~

   ```python
   get_cell(
      self,
      pos: Coordinate,
      by: str | List[str] | Callable[Cell, float],  # different from current implementation
      aggfunc: Callable[[List[Cell]], Cell],        # different from current implementation
      moore: bool,
      include_center: bool = False,
      radius: int = 1,
   )
   ```
   ~~so that the users can pass `min` and `max` as the `aggfunc` parameter. In addition, users can also define their own `by` parameter to be any function instead of cell attributes. But this API seems a bit too complicated.~~

3. The `apply_raster` method

   This is essentially the [gis:apply-raster](https://ccl.northwestern.edu/netlogo/docs/gis.html#gis:apply-raster) from NetLogo. But currently it works only if the input matrix has exactly the same dimension as the Raster Layer. Shall I make it more flexible so that the input matrix gets automatically resized to that of the Raster Layer?

Please feel free to suggest how to improve this PR. Thanks a lot!