### PR TITLE
Create raster layer from file

### DIFF
--- a/examples/rainfall/rainfall/space.py
+++ b/examples/rainfall/rainfall/space.py
@@ -3,7 +3,6 @@ import gzip
 
 import mesa
 import numpy as np
-import rasterio as rio
 
 from mesa_geo import Cell, RasterLayer
 from mesa_geo.geospace import GeoSpace
@@ -34,13 +33,14 @@ class CraterLake(GeoSpace):
 
     def set_elevation_layer(self, elevation_gzip_file, crs):
         with gzip.open(elevation_gzip_file, "rb") as elevation_file:
-            with rio.open(elevation_file, "r") as dataset:
-                values = dataset.read()
-                _, height, width = values.shape
-                total_bounds = dataset.bounds
-        raster_layer = RasterLayer(width, height, crs, total_bounds, cell_cls=LakeCell)
-        raster_layer.apply_raster(data=values, name="elevation")
-        raster_layer.apply_raster(data=np.zeros(values.shape), name="water_level")
+            raster_layer = RasterLayer.from_file(
+                elevation_file, cell_cls=LakeCell, attr_name="elevation"
+            )
+            raster_layer.crs = crs
+        raster_layer.apply_raster(
+            data=np.zeros(shape=(1, raster_layer.height, raster_layer.width)),
+            attr_name="water_level",
+        )
         super().add_layer(raster_layer)
 
     @property

--- a/examples/urban_growth/urban_growth/space.py
+++ b/examples/urban_growth/urban_growth/space.py
@@ -98,7 +98,7 @@ class City(GeoSpace):
             with gzip.open(data_file, "rb") as f:
                 with rio.open(f, "r") as dataset:
                     values = dataset.read()
-            self.raster_layer.apply_raster(values, name=attribute_name)
+            self.raster_layer.apply_raster(values, attr_name=attribute_name)
 
         for cell in self.raster_layer:
             cell.urban = True if cell.urban == 2 else False

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -38,12 +38,12 @@ class TestRasterLayer(unittest.TestCase):
         """
         self.assertEqual(self.raster_layer.cells[0][1].attribute_5, 3)
 
-        self.raster_layer.apply_raster(raster_data, name="elevation")
+        self.raster_layer.apply_raster(raster_data, attr_name="elevation")
         self.assertEqual(self.raster_layer.cells[0][1].elevation, 3)
 
     def test_get_min_cell(self):
         self.raster_layer.apply_raster(
-            np.array([[[1, 2], [3, 4], [5, 6]]]), name="elevation"
+            np.array([[[1, 2], [3, 4], [5, 6]]]), attr_name="elevation"
         )
 
         min_cell = min(
@@ -63,7 +63,7 @@ class TestRasterLayer(unittest.TestCase):
         self.assertEqual(min_cell.elevation, 1)
 
         self.raster_layer.apply_raster(
-            np.array([[[1, 2], [3, 4], [5, 6]]]), name="water_level"
+            np.array([[[1, 2], [3, 4], [5, 6]]]), attr_name="water_level"
         )
         min_cell = min(
             self.raster_layer.get_neighboring_cells(
@@ -77,7 +77,7 @@ class TestRasterLayer(unittest.TestCase):
 
     def test_get_max_cell(self):
         self.raster_layer.apply_raster(
-            np.array([[[1, 2], [3, 4], [5, 6]]]), name="elevation"
+            np.array([[[1, 2], [3, 4], [5, 6]]]), attr_name="elevation"
         )
 
         max_cell = max(


### PR DESCRIPTION
Partly addresses https://github.com/projectmesa/mesa-geo/issues/91.

The support for compressed files requires more effort, so I'm thinking to implement that in the next release. That probably won't be a breaking change, i.e., from

```python
RasterLayer.from_file(raster_file, cell_cls=Cell, attr_name=None)
```

to

```python
RasterLayer.from_file(raster_file, cell_cls=Cell, attr_name=None, compression="infer")
```