### PR TITLE
Export geoagents and raster cells

### DIFF
--- a/examples/geo_schelling/model.py
+++ b/examples/geo_schelling/model.py
@@ -56,9 +56,10 @@ class SchellingAgent(GeoAgent):
 class GeoSchelling(Model):
     """Model class for the Schelling segregation model."""
 
-    def __init__(self, density=0.6, minority_pc=0.2):
+    def __init__(self, density=0.6, minority_pc=0.2, export_data=False):
         self.density = density
         self.minority_pc = minority_pc
+        self.export_data = export_data
 
         self.schedule = RandomActivation(self)
         self.space = GeoSpace(warn_crs_conversion=False)
@@ -82,6 +83,11 @@ class GeoSchelling(Model):
                     agent.atype = 0
                 self.schedule.add(agent)
 
+    def export_agents_to_file(self) -> None:
+        self.space.get_agents_as_GeoDataFrame(agent_cls=SchellingAgent).to_crs(
+            "epsg:4326"
+        ).to_file("data/schelling_agents.geojson", driver="GeoJSON")
+
     def step(self):
         """Run one step of the model.
 
@@ -93,3 +99,6 @@ class GeoSchelling(Model):
 
         if self.happy == self.schedule.get_agent_count():
             self.running = False
+
+        if not self.running and self.export_data:
+            self.export_agents_to_file()

--- a/examples/geo_schelling/server.py
+++ b/examples/geo_schelling/server.py
@@ -21,6 +21,7 @@ class HappyElement(TextElement):
 model_params = {
     "density": mesa.visualization.Slider("Agent density", 0.6, 0.1, 1.0, 0.1),
     "minority_pc": mesa.visualization.Slider("Fraction minority", 0.2, 0.00, 1.0, 0.05),
+    "export_data": mesa.visualization.Checkbox("Export data after simulation", False),
 }
 
 

--- a/examples/rainfall/rainfall/server.py
+++ b/examples/rainfall/rainfall/server.py
@@ -10,6 +10,8 @@ from .space import LakeCell
 model_params = {
     "rain_rate": mesa.visualization.Slider("rain rate", 500, 0, 500, 5),
     "water_height": mesa.visualization.Slider("water height", 5, 1, 5, 1),
+    "num_steps": mesa.visualization.Slider("total number of steps", 20, 1, 100, 1),
+    "export_data": mesa.visualization.Checkbox("export data after simulation", False),
 }
 
 

--- a/tests/test_GeoSpace.py
+++ b/tests/test_GeoSpace.py
@@ -4,6 +4,7 @@ import uuid
 import warnings
 
 import numpy as np
+import pandas as pd
 import geopandas as gpd
 from shapely.geometry import Point
 
@@ -116,3 +117,20 @@ class TestGeoSpace(unittest.TestCase):
             self.geo_space.get_neighbors_within_distance(agent_to_check, distance=1.0)
         )
         self.assertEqual(len(neighbors), 7)
+
+    def test_get_agents_as_GeoDataFrame(self):
+        self.geo_space.add_agents(self.agents)
+
+        agents_list = [
+            {"geometry": agent.geometry, "unique_id": agent.unique_id}
+            for agent in self.agents
+        ]
+        agents_gdf = gpd.GeoDataFrame.from_records(agents_list, index="unique_id")
+        agents_gdf.crs = self.geo_space.crs
+
+        pd.testing.assert_frame_equal(
+            self.geo_space.get_agents_as_GeoDataFrame(), agents_gdf
+        )
+        self.assertEqual(
+            self.geo_space.get_agents_as_GeoDataFrame().crs, agents_gdf.crs
+        )

--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -37,9 +37,40 @@ class TestRasterLayer(unittest.TestCase):
           [5, 6]]]
         """
         self.assertEqual(self.raster_layer.cells[0][1].attribute_5, 3)
+        self.assertEqual(self.raster_layer.attributes, {"attribute_5"})
 
         self.raster_layer.apply_raster(raster_data, attr_name="elevation")
         self.assertEqual(self.raster_layer.cells[0][1].elevation, 3)
+        self.assertEqual(self.raster_layer.attributes, {"attribute_5", "elevation"})
+
+        with self.assertRaises(ValueError):
+            self.raster_layer.apply_raster(np.empty((1, 100, 100)))
+
+    def test_get_raster(self):
+        raster_data = np.array([[[1, 2], [3, 4], [5, 6]]])
+        self.raster_layer.apply_raster(raster_data)
+        """
+        (x, y) coordinates:
+        (0, 2), (1, 2)
+        (0, 1), (1, 1)
+        (0, 0), (1, 0)
+
+        values:
+        [[[1, 2],
+          [3, 4],
+          [5, 6]]]
+        """
+        self.raster_layer.apply_raster(raster_data, attr_name="elevation")
+        np.testing.assert_array_equal(
+            self.raster_layer.get_raster(attr_name="elevation"), raster_data
+        )
+
+        self.raster_layer.apply_raster(raster_data)
+        np.testing.assert_array_equal(
+            self.raster_layer.get_raster(), np.concatenate((raster_data, raster_data))
+        )
+        with self.assertRaises(ValueError):
+            self.raster_layer.get_raster("not_existing_attr")
 
     def test_get_min_cell(self):
         self.raster_layer.apply_raster(


### PR DESCRIPTION
- Extract raster cells as numpy array and save to file. Addresses https://github.com/projectmesa/mesa-geo/issues/91#issuecomment-1196219970.
- Extract geoagents as geodataframe.
- Update rainfall and geo_schelling examples to demonstrate.