### PR TITLE
fix spatial variation of water level in rainfall example

### DIFF
--- a/examples/rainfall/rainfall/model.py
+++ b/examples/rainfall/rainfall/model.py
@@ -106,6 +106,12 @@ class Rainfall(mesa.Model):
         self.schedule.step()
         self.datacollector.collect(self)
 
+        current_water_level = self.space.raster_layer.get_raster("water_level")
+        self.space.raster_layer.apply_raster(
+            current_water_level / current_water_level.max(),
+            "water_level_normalized",
+        )
+
         self.num_steps -= 1
         if self.num_steps == 0:
             self.running = False

--- a/examples/rainfall/rainfall/server.py
+++ b/examples/rainfall/rainfall/server.py
@@ -1,9 +1,9 @@
 from typing import Tuple
 
 import mesa
-
 from mesa_geo.visualization.ModularVisualization import ModularServer
 from mesa_geo.visualization.modules import MapModule
+
 from .model import Rainfall
 from .space import LakeCell
 
@@ -19,7 +19,15 @@ def cell_portrayal(cell: LakeCell) -> Tuple[float, float, float, float]:
     if cell.water_level == 0:
         return cell.elevation, cell.elevation, cell.elevation, 1
     else:
-        return 0, 0, 255, 1
+        # return a blue color gradient based on the normalized water level
+        # from the lowest water level colored as RGBA: (74, 141, 255, 1)
+        # to the highest water level colored as RGBA: (0, 0, 255, 1)
+        return (
+            (1 - cell.water_level_normalized) * 74,
+            (1 - cell.water_level_normalized) * 141,
+            255,
+            1,
+        )
 
 
 map_module = MapModule(

--- a/examples/rainfall/rainfall/space.py
+++ b/examples/rainfall/rainfall/space.py
@@ -11,6 +11,7 @@ from mesa_geo.geospace import GeoSpace
 class LakeCell(Cell):
     elevation: int | None
     water_level: int | None
+    water_level_normalized: float | None
 
     def __init__(
         self,
@@ -20,6 +21,7 @@ class LakeCell(Cell):
         super().__init__(pos, indices)
         self.elevation = None
         self.water_level = None
+        self.water_level_normalized = None
 
     def step(self):
         pass


### PR DESCRIPTION
Use scaled blue color to represent water level. The differences between cells are small so it may be hard to visualize the spatial variation.

Before the fix:

<img width="496" alt="rainfall_example backup" src="https://user-images.githubusercontent.com/10785873/194761865-50126cf0-4cba-49cb-a2ca-b3083026a831.png">

Now:

<img width="423" alt="rainfall_example" src="https://user-images.githubusercontent.com/10785873/194761866-cb0a76a3-b1de-4eee-a407-72684ab404bb.png">