### PR TITLE
fix youtube links in geo_schelling examples

### DIFF
--- a/examples/geo_schelling/README.md
+++ b/examples/geo_schelling/README.md
@@ -1,6 +1,6 @@
 # GeoSchelling Model (Polygons)
 
-![](../../docs/images/examples/geo_schelling.gif)
+[![](https://img.youtube.com/vi/ZnBk_eSw0_M/0.jpg)](https://www.youtube.com/watch?v=ZnBk_eSw0_M)
 
 ## Summary
 

--- a/examples/geo_schelling_points/README.md
+++ b/examples/geo_schelling_points/README.md
@@ -1,6 +1,6 @@
 # GeoSchelling Model (Points & Polygons)
 
-![](../../docs/images/examples/geo_schelling_points.gif)
+[![](https://img.youtube.com/vi/iLMU6jfmir8/0.jpg)](https://www.youtube.com/watch?v=iLMU6jfmir8)
 
 ## Summary
 


### PR DESCRIPTION
Somehow the gifs got incorrectly merged into the commits. Probably a mistake made during the rebase.