### PR TITLE
fix WMSWebTile.to_dict() method

### DIFF
--- a/mesa_geo/tile_layers.py
+++ b/mesa_geo/tile_layers.py
@@ -54,4 +54,4 @@ class WMSWebTile(RasterWebTile):
     The available options can be found at: https://leafletjs.com/reference.html#tilelayer-wms
     """
 
-    kind = "wms_web_tile"
+    kind: str = "wms_web_tile"

--- a/mesa_geo/visualization/modules/MapVisualization.py
+++ b/mesa_geo/visualization/modules/MapVisualization.py
@@ -101,9 +101,13 @@ class MapModule(VisualizationElement):
         for layer in model.space.layers:
             if isinstance(layer, RasterBase):
                 if isinstance(layer, RasterLayer):
-                    layer = layer.to_image(colormap=self.portrayal_method)
+                    layer_to_render = layer.to_image(
+                        colormap=self.portrayal_method
+                    ).to_crs(self._crs)
+                else:
+                    layer_to_render = layer.to_crs(self._crs)
                 layers["rasters"].append(
-                    image_to_url(layer.to_crs(self._crs).values.transpose([1, 2, 0]))
+                    image_to_url(layer_to_render.values.transpose([1, 2, 0]))
                 )
             elif isinstance(layer, gpd.GeoDataFrame):
                 layers["vectors"].append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ extend-ignore = [
     "PGH004", # Use specific rule codes when using `noqa` TODO
     "B905", # `zip()` without an explicit `strict=` parameter
     "N802", # Function name should be lowercase
+    "N999", # Invalid module name
 ]
 extend-exclude = ["docs", "build"]
 # Hardcode to Python 3.8.

--- a/tests/test_WMSWebTile.py
+++ b/tests/test_WMSWebTile.py
@@ -1,0 +1,40 @@
+import unittest
+
+import mesa_geo as mg
+
+
+class TestWMSWebTile(unittest.TestCase):
+    def setUp(self) -> None:
+        self.map_tile_url = "https://gis.charttools.noaa.gov/arcgis/rest/services/MCS/NOAAChartDisplay/MapServer/exts/MaritimeChartService/WMSServer/"
+
+    def test_to_dict(self):
+        map_tile = mg.WMSWebTile(
+            url=self.map_tile_url,
+            options={
+                "layers": "0,1,2,3,4,5,6,7,8,9,10,11,12",
+                "version": "1.3.0",
+                "format": "image/png",
+            },
+        )
+        self.assertEqual(
+            map_tile.to_dict(),
+            {
+                "kind": "wms_web_tile",
+                "url": self.map_tile_url,
+                "options": {
+                    "layers": "0,1,2,3,4,5,6,7,8,9,10,11,12",
+                    "version": "1.3.0",
+                    "format": "image/png",
+                },
+            },
+        )
+
+        map_tile = mg.WMSWebTile(url=self.map_tile_url)
+        self.assertEqual(
+            map_tile.to_dict(),
+            {
+                "kind": "wms_web_tile",
+                "url": self.map_tile_url,
+                "options": None,
+            },
+        )


### PR DESCRIPTION
There are two web tiles classes with different `kind` attributes:

```python
@dataclass
class RasterWebTile:
    ...
    kind: str = "raster_web_tile"
    ...

@dataclass
class WMSWebTile(RasterWebTile):
    ...
    kind = "wms_web_tile"
    ...
```

Apparently `WMSWebTile` also needs to type-hint its `kind` field - otherwise it won't get overwritten, as explained [here](https://stackoverflow.com/questions/72623411/inherited-dataclass-default-value-override-only-works-if-type-hints-match).

This PR fixes this issue.