### PR TITLE
ci: update os, python versions, and dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,8 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
+      # Check for updates to GitHub Actions every week
       interval: "weekly"

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -19,14 +19,11 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        #os: [windows, ubuntu, macos]
-        # TODO need to figure out how to install libspatialindex-dev for
-        # windows and macos
-        os: [ubuntu]
-        python-version: ["3.10"]
+        os: [windows, ubuntu, macos]
+        python-version: ["3.11"]
         include:
           - os: ubuntu
-            python-version: "3.11"
+            python-version: "3.10"
           - os: ubuntu
             python-version: "3.9"
           - os: ubuntu
@@ -38,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - uses: actions/cache@v3
@@ -46,22 +43,19 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('Pipfile.lock') }}
     - name: Install dependencies
-      run: |
-        sudo apt-get install libspatialindex-dev
-        pip install .
-        pip install pytest pytest-cov
+      run: pip install wheel && pip install .[dev]
     - name: Test with pytest
       run: pytest --cov=mesa_geo tests/ --cov-report=xml
     - if: matrix.os == 'ubuntu'
       name: Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
 
   lint-ruff:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - run: pip install ruff
@@ -75,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - run: pip install black[jupyter]


### PR DESCRIPTION
- Include windows and macos in ci builds
- Set python versions to be the same as in Mesa
- Update dependabot to be the same as in Mesa