### PR TITLE
ci: pin ruff version to v0.0.254

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - run: pip install ruff
+    - run: pip install ruff==0.0.254
     - name: Lint with ruff
       # Include `--format=github` to enable automatic inline annotations.
       # Use settings from pyproject.toml.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ dev =
     coverage
     pytest
     pytest-cov
-    ruff
+    ruff==0.0.254
 docs =
     myst-parser
     sphinx


### PR DESCRIPTION
Following https://github.com/projectmesa/mesa/pull/1609 to avoid unexpected lint errors.