### PR TITLE
pin rasterio to 1.3.7 to pass tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,9 @@ install_requires =
     geopandas
     libpysal
     rtree
-    rasterio>=1.3b1
+    # unpin rasterio version when the following issue is fixed:
+    # https://github.com/rasterio/rasterio/issues/2863
+    rasterio==1.3.7
     shapely
     numpy
     pyproj


### PR DESCRIPTION
Rasterio's recent release 1.3.8 is breaking our example tests. This PR pins rasterio to 1.3.7.

Will undo this when https://github.com/rasterio/rasterio/issues/2863 is fixed.