### PR TITLE
fix rtd build error and upgrade to python 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,9 +12,13 @@ sphinx:
 formats:
   - pdf
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Fix build error in readthedocs:

```
Error

Problem in your project's configuration. Invalid configuration option "build.os": build not found
```

Also upgrade to Python 3.9 following Mesa.