### PR TITLE
create and update rtree spatial index only when needed

### DIFF
--- a/tests/test_GeoSpace.py
+++ b/tests/test_GeoSpace.py
@@ -265,3 +265,13 @@ class TestGeoSpace(unittest.TestCase):
             agent.unique_id for agent in self.geo_space.agents_at((1, 1))
         }
         self.assertEqual(agents_id_found, agents_id)
+
+    def test_get_neighbors(self):
+        self.geo_space.add_agents(self.polygon_agent)
+        self.assertEqual(len(self.geo_space.get_neighbors(self.polygon_agent)), 0)
+        self.geo_space.add_agents(self.touching_agent)
+        self.assertEqual(len(self.geo_space.get_neighbors(self.polygon_agent)), 1)
+        self.assertEqual(
+            self.geo_space.get_neighbors(self.polygon_agent)[0].unique_id,
+            self.touching_agent.unique_id,
+        )


### PR DESCRIPTION
Implements https://github.com/projectmesa/mesa-geo/issues/104

Check performance of the gis example models. Execution time is the average of 10 runs, where each run contains model initialization followed by 10 steps.

| model | time in seconds | time in seconds (this PR) |
| :---: | :---: | :---: |
| agents_networks<br>(num_agents=100) | 3.18 | 0.44 |
| agents_networks<br>(num_agents=500) | 37.28 | 1.16 |
| geo_schelling<br>(default parameters) | 0.79 | 0.62 |
| geo_schelling (points & polygons)<br>(default parameters) | 1.49 | 1.19 |
| geo_sir<br>(default parameters) | 0.13 | 0.13 |
| population<br>(default parameters) | 12.88 | 10.31 |