### PR TITLE
update ga workflows to be consistent with mesa

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -28,8 +28,6 @@ jobs:
             python-version: "3.10"
           - os: ubuntu
             python-version: "3.9"
-          - os: ubuntu
-            python-version: "3.8"
           # Disabled for now. See https://github.com/projectmesa/mesa/issues/1253
           #- os: ubuntu
           #  python-version: 'pypy-3.8'
@@ -51,28 +49,3 @@ jobs:
     - if: matrix.os == 'ubuntu'
       name: Codecov
       uses: codecov/codecov-action@v3
-
-  lint-ruff:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-    - run: pip install ruff==0.1.5
-    - name: Lint with ruff
-      # Use settings from pyproject.toml.
-      run: ruff .
-
-  lint-black:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-    - run: pip install black[jupyter]
-    - name: Lint with black
-      run: black --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 on:
   push:
+    tags:
+    - "v*"
     branches:
     - main
     - release**


### PR DESCRIPTION
- drop support for python 3.8
- remove redundant linters which are included in pre-commit.ci
- run release workflow when tags are created