### PR TITLE
fix: remove old map layers before rendering new layers

### DIFF
--- a/mesa_geo/geospace.py
+++ b/mesa_geo/geospace.py
@@ -458,5 +458,9 @@ class _AgentLayer:
                 }
                 agents_list.append(agent_dict)
         agents_gdf = gpd.GeoDataFrame.from_records(agents_list, index="unique_id")
+        # workaround for geometry column not being set in `from_records`
+        # see https://github.com/geopandas/geopandas/issues/3152
+        # may be removed when the issue is resolved
+        agents_gdf.set_geometry("geometry", inplace=True)
         agents_gdf.crs = crs
         return agents_gdf

--- a/mesa_geo/visualization/templates/js/MapModule.js
+++ b/mesa_geo/visualization/templates/js/MapModule.js
@@ -32,13 +32,19 @@ const MapModule = function (view, zoom, map_width, map_height, tiles, scale_opti
         }
     }
 
+    let mapLayers = []
     let hasFitBounds = false
     this.renderLayers = function (layers) {
+        mapLayers.forEach(layer => {layer.remove()})
+        mapLayers = []
+
         layers.rasters.forEach(function (layer) {
-            L.imageOverlay(layer, layers.total_bounds).addTo(Lmap)
+            const rasterLayer = L.imageOverlay(layer, layers.total_bounds).addTo(Lmap)
+            mapLayers.push(rasterLayer)
         })
         layers.vectors.forEach(function (layer) {
-            L.geoJSON(layer).addTo(Lmap)
+            const vectorLayer = L.geoJSON(layer).addTo(Lmap)
+            mapLayers.push(vectorLayer)
         })
         if (!hasFitBounds && !customView && layers.total_bounds.length !== 0) {
             Lmap.fitBounds(layers.total_bounds)
@@ -66,6 +72,8 @@ const MapModule = function (view, zoom, map_width, map_height, tiles, scale_opti
 
     this.reset = function () {
         agentLayer.remove()
+        mapLayers.forEach(layer => {layer.remove()})
+        mapLayers = []
     }
 }
 

--- a/tests/test_GeoSpace.py
+++ b/tests/test_GeoSpace.py
@@ -143,6 +143,10 @@ class TestGeoSpace(unittest.TestCase):
             for agent in self.agents
         ]
         agents_gdf = gpd.GeoDataFrame.from_records(agents_list, index="unique_id")
+        # workaround for geometry column not being set in `from_records`
+        # see https://github.com/geopandas/geopandas/issues/3152
+        # may be removed when the issue is resolved
+        agents_gdf.set_geometry("geometry", inplace=True)
         agents_gdf.crs = self.geo_space.crs
 
         pd.testing.assert_frame_equal(


### PR DESCRIPTION
Fix https://github.com/projectmesa/mesa-geo/issues/192

Layers were added to leaflet map at each model step, but were never removed. This resulted in too many layers to be unnecessarily rendered when model kept running (shown below).

<img width="1007" alt="Screenshot 2024-03-22 at 11 05 21" src="https://github.com/projectmesa/mesa-geo/assets/10785873/1a113f61-dff5-4e78-94dc-3c00c687fb1c">


This fix removes old layers before new layers are added into leaflet map.