### PR TITLE
add manual trigger to github actions

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -12,6 +12,7 @@ on:
     paths-ignore:
       - '**.md'
       - '**.rst'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
There are three failing PRs (https://github.com/projectmesa/mesa-geo/pull/187, https://github.com/projectmesa/mesa-geo/pull/188, https://github.com/projectmesa/mesa-geo/pull/189) but a fix to test cases was merged in another PR https://github.com/projectmesa/mesa-geo/pull/194. I couldn't find a way to manually re-run failed jobs in the three failing PRs. This PR should add a mutual trigger to run jobs.

If I'm missing something and it's possible to re-run jobs, then this PR is not necessary.