### PR TITLE
pyproject.toml: Always use latest ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-  "ruff~=0.1.1",   # Update periodically
+  "ruff",
   "coverage",
   "pytest >= 4.6",
   "pytest-cov",


### PR DESCRIPTION
ruff is now a lot more stable than in the beginning, and since we're inclined to forget updating these things let's just use the latest version of ruff.

We will notice it automatically when they adopt a new convention.