### PR TITLE
pyproject.toml: Use mesa version smaller than 3 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 readme = "README.md"
 dependencies = [
-  "mesa",
+  "mesa<3",
   "geopandas",
   "libpysal",
   "rtree",


### PR DESCRIPTION
Require a mesa version smaller than 3 for now, until development is moved to Mesa-geo 1.0.