### PR TITLE
.readthedocs.yaml: Use latest Ubuntu and Python versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,9 @@ formats:
   - pdf
 
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-lts-latest
   tools:
-    python: "3.9"
+    python: latest
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Use latest Ubuntu and Python versions for Readthedocs. These are faster and throw more detailed errors if anything goes wrong.