### PR TITLE
docs: remove api docs entry for removed visualization module

### DIFF
--- a/docs/apis/visualization.rst
+++ b/docs/apis/visualization.rst
@@ -3,14 +3,3 @@ Visualization
 
 .. automodule:: visualization.__init__
    :members:
-
-Modules
-~~~~~~~
-
-.. automodule:: visualization.modules.__init__
-   :members:
-
-.. automodule:: visualization.modules.MapVisualization
-    :members:
-    :inherited-members:
-    :undoc-members:


### PR DESCRIPTION
This is to remove the following warnings from readthedocs:

```bash
WARNING: autodoc: failed to import module 'modules.__init__' from module 'visualization'; the following exception was raised:
No module named 'visualization.modules' [autodoc.import_object]
WARNING: autodoc: failed to import module 'modules.MapVisualization' from module 'visualization'; the following exception was raised:
No module named 'visualization.modules' [autodoc.import_object]
```

`visualization.modules` was removed in https://github.com/projectmesa/mesa-geo/pull/212.