### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
 docs = [
   "sphinx",
   "ipython",
+  "ipykernel", # necessary to ensure python3 kernel
   "pydata_sphinx_theme",
   "seaborn",
   "myst-nb",


### PR DESCRIPTION
Attempting to fix build failure; fix is based on [this documentation](https://nbsphinx.readthedocs.io/en/0.8.2/installation.html)

There is a brute force fix where `conf.py` replace the kernel manually, but I would prefer not to use. 