### PR TITLE
pre-commit: Use Python 3.10+ for pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.17.0
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0  # Use the ref you want to point at
     hooks:


### PR DESCRIPTION
Since https://github.com/projectmesa/mesa-geo/pull/208 mesa-geo requires Python 3.10+, this PR updates pre-commit to check for Python 3.10+ features as wel.