### PR TITLE
pre-commit: Add --fix argument to Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,22 +5,23 @@ ci:
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.6
+  rev: v0.6.3
   hooks:
-    # Run the linter.
+    # Run the linter with fix argument.
     - id: ruff
       types_or: [ python, pyi, jupyter ]
+      args: [--fix]  # This will enable automatic fixing of lint issues where possible.
     # Run the formatter.
     - id: ruff-format
       types_or: [ python, pyi, jupyter ]
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
-    hooks:
-    -   id: pyupgrade
-        args: [--py310-plus]
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0  # Use the ref you want to point at
-    hooks:
-    -   id: trailing-whitespace
-    -   id: check-toml
-    -   id: check-yaml
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.17.0
+  hooks:
+    - id: pyupgrade
+      args: [--py310-plus]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0  # Use the ref you want to point at
+  hooks:
+    - id: trailing-whitespace
+    - id: check-toml
+    - id: check-yaml


### PR DESCRIPTION
Add `--fix` argument to Ruff in the pre-commit configuration. This allows automatically fixing safe issues (note it's not `--unsafe-fixes`).

For context, we also have this enabled on the main mesa repo.