### PR TITLE
intro_tutorial: Don't install mesa explicitly, let mesa-geo do that

### DIFF
--- a/docs/tutorials/intro_tutorial.ipynb
+++ b/docs/tutorials/intro_tutorial.ipynb
@@ -50,7 +50,6 @@
    "outputs": [],
    "source": [
     "#Run this if in colab or if you need to install mesa and mesa-geo in your local environment. \n",
-    "!pip install mesa --quiet\n",
     "!pip install mesa-geo --quiet\n",
     "!mkdir -p data\n",
     "!wget -P data https://raw.githubusercontent.com/projectmesa/mesa-geo/main/docs/tutorials/data/TorontoNeighbourhoods.geojson"


### PR DESCRIPTION
mesa-geo knows what mesa version is compatible with it and has that as a dependency defined in the `pyproject.toml`. So we don't need to install Mesa separately, that can only mess up the mesa version installed.

Currently:

https://github.com/projectmesa/mesa-geo/blob/d8a13560c600faad55432bec6a1daa98387ea80e/pyproject.toml#L42