### PR TITLE
fix raster layer rendering in solaraviz

### DIFF
--- a/mesa_geo/visualization/components/geospace_leaflet.py
+++ b/mesa_geo/visualization/components/geospace_leaflet.py
@@ -46,7 +46,12 @@ def GeoSpaceLeaflet(model, agent_portrayal, view, tiles, **kwargs):
         [ipyleaflet.TileLayer.element(url=map_drawer.tiles["url"])] if tiles else []
     )
     for layer in model_view["layers"]["rasters"]:
-        layers.append(ipyleaflet.ImageOverlay(element=image_to_url(layer)))
+        layers.append(
+            ipyleaflet.ImageOverlay(
+                url=layer["url"],
+                bounds=layer["bounds"],
+            )
+        )
     for layer in model_view["layers"]["vectors"]:
         layers.append(ipyleaflet.GeoJSON(element=layer))
     ipyleaflet.Map.element(
@@ -163,7 +168,22 @@ class MapModule:
                 else:
                     layer_to_render = layer.to_crs(self._crs)
                 layers["rasters"].append(
-                    image_to_url(layer_to_render.values.transpose([1, 2, 0]))
+                    {
+                        "url": image_to_url(
+                            layer_to_render.values.transpose([1, 2, 0])
+                        ),
+                        # longlat [min_x, min_y, max_x, max_y] to latlong [[min_y, min_x], [max_y, max_x]]
+                        "bounds": [
+                            [
+                                layer_to_render.total_bounds[1],
+                                layer_to_render.total_bounds[0],
+                            ],
+                            [
+                                layer_to_render.total_bounds[3],
+                                layer_to_render.total_bounds[2],
+                            ],
+                        ],
+                    }
                 )
             elif isinstance(layer, gpd.GeoDataFrame):
                 layers["vectors"].append(

--- a/tests/test_MapModule.py
+++ b/tests/test_MapModule.py
@@ -228,8 +228,14 @@ class TestMapModule(unittest.TestCase):
             map_module.render(self.model).get("layers"),
             {
                 "rasters": [
-                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP4DwQACfsD/Wj6HMwAAAAASUVORK5CYII=",
-                    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYGD4DwABBAEAgLvRWwAAAABJRU5ErkJggg==",
+                    {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP4DwQACfsD/Wj6HMwAAAAASUVORK5CYII=",
+                        "bounds": [[0.0, 0.0], [1.0, 1.0]],
+                    },
+                    {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYGD4DwABBAEAgLvRWwAAAABJRU5ErkJggg==",
+                        "bounds": [[0.0, 0.0], [1.0, 1.0]],
+                    },
                 ],
                 "total_bounds": [[0.0, 0.0], [1.0, 1.0]],
                 "vectors": [],


### PR DESCRIPTION
Raster layers were not rendered in the new SolaraViz. This PR should fix it.

Will update the raster gis examples after this is merged.