### PR TITLE
Require Mesa 3.0 stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 readme = "README.md"
 dependencies = [
-  "mesa[rec]>=3.0.0a4",
+  "mesa[rec]>=3.0",
   "geopandas",
   "libpysal",
   "rtree",


### PR DESCRIPTION
Require Mesa 3.0 stable, so we can make sure all features from Mesa 3 can be used in Mesa-geo.