### PR TITLE
Add Cell.xy for RasterLayer cell coordinates and clarify pos/indices semantics

### DIFF
--- a/tests/test_RasterLayer.py
+++ b/tests/test_RasterLayer.py
@@ -89,7 +89,7 @@ class TestRasterLayer(unittest.TestCase):
             self.raster_layer.get_neighboring_cells(pos=(0, 2), moore=True),
             key=lambda cell: cell.elevation,
         )
-        self.assertEqual(min_cell.grid_pos, (1, 2))
+        self.assertEqual(min_cell.pos, (1, 2))
         self.assertEqual(min_cell.elevation, 2)
 
         min_cell = min(
@@ -98,7 +98,7 @@ class TestRasterLayer(unittest.TestCase):
             ),
             key=lambda cell: cell.elevation,
         )
-        self.assertEqual(min_cell.grid_pos, (0, 2))
+        self.assertEqual(min_cell.pos, (0, 2))
         self.assertEqual(min_cell.elevation, 1)
 
         self.raster_layer.apply_raster(
@@ -110,7 +110,7 @@ class TestRasterLayer(unittest.TestCase):
             ),
             key=lambda cell: cell.elevation + cell.water_level,
         )
-        self.assertEqual(min_cell.grid_pos, (0, 2))
+        self.assertEqual(min_cell.pos, (0, 2))
         self.assertEqual(min_cell.elevation, 1)
         self.assertEqual(min_cell.water_level, 1)
 
@@ -123,21 +123,19 @@ class TestRasterLayer(unittest.TestCase):
             self.raster_layer.get_neighboring_cells(pos=(0, 2), moore=True),
             key=lambda cell: cell.elevation,
         )
-        self.assertEqual(max_cell.grid_pos, (1, 1))
+        self.assertEqual(max_cell.pos, (1, 1))
         self.assertEqual(max_cell.elevation, 4)
 
     def test_deprecated_pos_indices_accessors(self):
         cell = self.raster_layer.cells[0][0]
         with warnings.catch_warnings(record=True) as captured:
             warnings.simplefilter("always")
-            self.assertEqual(cell.pos, (0, 0))
             self.assertEqual(cell.indices, (2, 0))
-        self.assertEqual(len(captured), 2)
+        self.assertEqual(len(captured), 1)
         self.assertTrue(
             all(issubclass(item.category, DeprecationWarning) for item in captured)
         )
-        self.assertIn("Cell.pos is deprecated", str(captured[0].message))
-        self.assertIn("Cell.indices is deprecated", str(captured[1].message))
+        self.assertIn("Cell.indices is deprecated", str(captured[0].message))
 
     def test_transform_accuracy(self):
         """
@@ -145,7 +143,7 @@ class TestRasterLayer(unittest.TestCase):
         """
         # Bottom-Left (grid=0,0) -> Array Row=2, Col=0
         bl_cell = self.raster_layer.cells[0][0]
-        self.assertEqual(bl_cell.grid_pos, (0, 0))
+        self.assertEqual(bl_cell.pos, (0, 0))
         self.assertEqual(bl_cell.rowcol, (2, 0))
 
         # Transform logic: x_coord, y_coord = transform * (col + 0.5, row + 0.5)
@@ -155,7 +153,7 @@ class TestRasterLayer(unittest.TestCase):
 
         # Top-Right (grid=1,2) -> Array Row=0, Col=1
         tr_cell = self.raster_layer.cells[1][2]
-        self.assertEqual(tr_cell.grid_pos, (1, 2))
+        self.assertEqual(tr_cell.pos, (1, 2))
         self.assertEqual(tr_cell.rowcol, (0, 1))
 
         expected_xy = rio.transform.xy(
@@ -171,4 +169,5 @@ class TestRasterLayer(unittest.TestCase):
             transformed_layer.transform, *transformed_cell.rowcol, offset="center"
         )
         self.assertEqual(transformed_cell.xy, expected_xy)
+        self.assertEqual(self.raster_layer.cells[0][0].xy, original_xy)
         self.assertNotEqual(transformed_cell.xy, original_xy)


### PR DESCRIPTION
### Summary

This PR introduces explicit coordinate attributes (`cell.xy`, `cell.grid_pos`, `cell.rowcol`) to `Cell` objects in `RasterLayer`. It disambiguates real-world geographic coordinates from internal grid indices and deprecates the ambiguous `cell.pos` and `cell.indices` properties.

### Motive

Closes #298 

### Implementation

1. **Updated `mesa_geo/raster_layers.py`:**
2. **Updated `RasterLayer` Initialization:**
3. **Test Suite Updates:**



### Usage Examples

**Old Way (Ambiguous & Manual Calculation):**

```python
cell = raster_layer.cells[0][0]

print(cell.pos)  # Output: (0, 0)
transform = raster_layer.transform
real_x, real_y = transform * (cell.indices[1] + 0.5, cell.indices[0] + 0.5)

```

**New Way:**

```python
cell = raster_layer.cells[0][0]

print(cell.xy)       # Output: (-122.45, 37.75)
print(cell.grid_pos) # Output: (0, 0)
print(cell.rowcol)   # Output: (10, 0)

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `apply_raster` / `get_raster` accept `attr_name` for named raster layers.
  * Added `xy` property exposing real-world cell center coordinates.

* **Deprecations**
  * Cell position accessors `pos` and `indices` deprecated in favor of `grid_pos` and `rowcol`; deprecated accessors emit warnings.

* **Other**
  * Per-cell attribute renamed to `val`; tests added/updated for deprecation warnings and coordinate transforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->